### PR TITLE
Add community committee charter

### DIFF
--- a/GOVERNANCE.MD
+++ b/GOVERNANCE.MD
@@ -18,9 +18,7 @@ Section 4. Establishment of the Community Committee.
 
 Membership is for 6 months. The group will ask on a regular basis if the expiring members would like to stay on. A member just needs to reply to renew. There is no fixed size of the CC. However, the expected target for Advisers, as defined in Section 10, is between 9 and 12, to ensure adequate coverage of important areas of community expertise, balanced with the ability to make decisions efficiently.
 
-In the case where an individual CC member attends fewer than 20% of the regularly scheduled meetings held within a six month period, and does not communicate with the CC their intention not to attend those
-+meetings, the member shall be asked to consider voluntarily resigning their
-+membership.
+In the case where an individual CC member attends fewer than 25% of the regularly scheduled meetings held within a six month period, does not attend at least one meeting every three months, and does not proactively communicate with the CC their intention not to attend those meetings, the member shall be asked to voluntarily resign their membership. Should a member fail to attend 100% of the meetings within a six month period, the member shall be automatically removed from the TSC. In such cases, the member may ask to continue as an invited observer to TSC meetings.
 
 There is no specific set of requirements or qualifications for CC membership beyond these rules. The CC may add additional members to the CC by a standard CC motion and vote. A CC member may be removed from the CC by voluntary resignation, or by a standard CC motion.
 
@@ -28,9 +26,9 @@ Changes to CC membership should be posted in the agenda, and may be suggested as
 
 No more than one-fourth of the CC members may be affiliated with the same employer or leadership of a community/ecosystem organization. If removal or resignation of a CC member, or a change of employment by a CC member, creates a situation where more than one-fourth of the CC membership shares an employer, then the situation must be immediately remedied by the resignation or removal of one or more CC members affiliated with the over-represented employer(s).
 
-The CC members shall consist of active members of Community Projects as defined in Section 10.
+The CC members shall consist of active members of Community Projects and the two Individual Membership Directors as defined in Section 10.
 
-The CC shall meet regularly using tools that enable participation by the community (e.g. weekly on a Google Hangout On Air, or through any other appropriate means selected by the CC). The meeting shall be directed by the CC Chairperson. Minutes or an appropriate recording shall be taken and made available to the community through accessible public postings.
+The CC shall meet regularly using tools that enable participation by the community (e.g. weekly on a Google Hangout On Air, or through any other appropriate means selected by the CC). The meeting shall be directed by the Individual Membership Directors. Minutes or an appropriate recording shall be taken and made available to the community through accessible public postings.
 
 Section 5. Responsibilities of the CC.
 
@@ -79,6 +77,7 @@ Section 9. Roles
 - The Node.js Foundation community git repository will be maintained by the CC and additional Collaborators who are added by the CC on an ongoing basis.
 - Individuals making significant and valuable contributions, “Contributor(s)”, are made Collaborators and given commit-access to the project. These individuals are identified by the CC and their addition as Collaborators is discussed during the weekly CC meeting. Modifications of the contents of the git repository are made on a collaborative basis as defined in the development process.
 - Collaborators may opt to elevate significant or controversial modifications, or modifications that have not found consensus to the CC for discussion by assigning the cc-agenda tag to a pull request or issue. The CC should serve as the final arbiter where required. The CC will maintain and publish a list of current Collaborators by Project, as well as a development process guide for Collaborators and Contributors looking to participate in the effort.
+- Individual Membership Directors of the Node.js Foundation are the Node.js project’s community voice on the board. There are two individual directors that sit on the Node.js Foundation board and they each serve a two-year term. Each Individual Membership Director is responsible for soliciting feedback and data that represents the wishes of other individual members and the community at large. These directors participate and observe CC meetings in order to deliver monthly updates to the Board of the project. They deliver monthly updates to the CC on what the Board is doing. They have been entrusted with the duty to make decisions based on the information they receive to best represent the community, and can gather input for proposals when relevant and granted permission to do so by the Board.
 
 Section 10. Definitions
 

--- a/GOVERNANCE.MD
+++ b/GOVERNANCE.MD
@@ -2,11 +2,11 @@
 
 Section 1. Guiding Principle.
 
-The Node.js Foundation will operate transparently, openly, collaboratively, and ethically. Project proposals, timelines, and status must not merely be open, but also easily visible to the entire ecosystem.
+The Community Committee will operate transparently, openly, collaboratively, and ethically. Project proposals, timelines, and status must not merely be open, but also easily visible to the entire ecosystem.
 
 Section 2. Evolution of Node.js Foundation Governance.
 
-Most large, complex open source communities have both a business and a technical governance model. Node.js Foundation’s leadership contains both a Technical Steering Committee (“TSC”) and Maintainers for major components or subsystems. Node.js Foundation’s business leadership is instantiated in a Board of Directors (the “Board”). Community activities, such as events, fall outside of the realm of code and documentation that the TSC oversees. The champions of these organizations have very different skillsets, talents, and concerns. The community organizations of Node.js have long been important to the growth and vitality of the project and will be recognized as the Community Committee(CC) as represented on the Board by the existing Individual Membership Board Directors.
+Most large, complex open source communities have both a business and a technical governance model. Node.js Foundation’s leadership contains both a Technical Steering Committee (“TSC”) and Maintainers for major components or subsystems. Node.js Foundation’s business leadership is instantiated in a Board of Directors (the “Board”). Community activities, such as events, fall outside of the realm of code and documentation that the TSC oversees. The champions of these organizations have very different skillsets, talents, and concerns. The community organizations of Node.js have long been important to the growth and vitality of the project and will be recognized as the Community Committee("CC") as represented on the Board by the existing Individual Membership Board Directors.
 
 This Community Committee Charter reflects a formal role and the relevance of the voice of community for the governance of Node.js Foundation. The charter amendment process is for the Community Committee(CC) to propose changes using simple majority of the full CC, the proposed changes being subject to review and approval by the Board. The Board may additionally make amendments to the CC charter at any time, though the Board will not interfere with day-to-day discussions, votes or meetings of the CC.
 
@@ -16,7 +16,11 @@ The Board will set the overall CC Policy. The policy will describe the overarchi
 
 Section 4. Establishment of the Community Committee.
 
-CC memberships are not time-limited. There is no fixed size of the CC. However, the expected target is between 9 and 12, to ensure adequate coverage of important areas of community expertise, balanced with the ability to make decisions efficiently.
+Membership is for 6 months. The group will ask on a regular basis if the expiring members would like to stay on. A member just needs to reply to renew. There is no fixed size of the CC. However, the expected target for Advisers, as defined in Section 10, is between 9 and 12, to ensure adequate coverage of important areas of community expertise, balanced with the ability to make decisions efficiently.
+
+In the case where an individual CC member attends fewer than 20% of the regularly scheduled meetings held within a six month period, and does not communicate with the CC their intention not to attend those
++meetings, the member shall be asked to consider voluntarily resigning their
++membership.
 
 There is no specific set of requirements or qualifications for CC membership beyond these rules. The CC may add additional members to the CC by a standard CC motion and vote. A CC member may be removed from the CC by voluntary resignation, or by a standard CC motion.
 
@@ -24,7 +28,7 @@ Changes to CC membership should be posted in the agenda, and may be suggested as
 
 No more than one-fourth of the CC members may be affiliated with the same employer or leadership of a community/ecosystem organization. If removal or resignation of a CC member, or a change of employment by a CC member, creates a situation where more than one-fourth of the CC membership shares an employer, then the situation must be immediately remedied by the resignation or removal of one or more CC members affiliated with the over-represented employer(s).
 
-The CC members shall consist of active members of Community Projects as defined in Section 7.
+The CC members shall consist of active members of Community Projects as defined in Section 10.
 
 The CC shall meet regularly using tools that enable participation by the community (e.g. weekly on a Google Hangout On Air, or through any other appropriate means selected by the CC). The meeting shall be directed by the CC Chairperson. Minutes or an appropriate recording shall be taken and made available to the community through accessible public postings.
 
@@ -39,13 +43,11 @@ Subject to such policies as may be set by the Board, the CC is responsible for a
 - Project governance and process (including this policy)
 - Recommendations for building and developing community projects that align with needs of Node.js
 - Mediating cultural conflicts between Foundation and/or community projects
-- The CC will serve as Node.js Foundation’s primary community liaison body with external open source projects, consortiums and groups.
+- Serve as Node.js Foundation’s primary community liaison body with external open source projects, consortiums and groups.
 
 Section 6. Node.js Foundation Operations.
 
 The CC will establish and maintain a process of support for Node.js community projects. The process will establish guidelines for how culture and values of the community can be supported.
-
-
 
 The CC is responsible for vetting organizations that will be supported through means such as monetary sponsorship, promotion, resource provisioning, etc. for example requirements such as the organization in question having and executing a Code of Conduct or not conflicting with Node.js Foundation’s goals and priorities.
 
@@ -57,8 +59,8 @@ Leadership roles in Node.js Foundation Community Committee will be peer elected 
 
 For election of persons (CC Chairperson, Advisors, etc.) a multiple-candidate method should be used, e.g.:
 
-- ●  Condorcet: http://en.wikipedia.org/wiki/Condorcet_method or
-- ●  Single Transferable Vote: http://en.wikipedia.org/wiki/Single_transferable_vote
+- Condorcet: http://en.wikipedia.org/wiki/Condorcet_method or
+- Single Transferable Vote: http://en.wikipedia.org/wiki/Single_transferable_vote
 
 Multiple-candidate methods may be reduced to simple election by plurality when there are only two candidates for one position to be filled. No election is required if there is only one candidate and no objections to the candidate's election. Nominations for organizations that should be represented on the Community Committee will take place in the GitHub repository. A representative for these organizations shall be selected within the organizations by those active in it.
 
@@ -70,10 +72,7 @@ For internal project decisions, Collaborators shall operate under Lazy Consensus
 
 The CC follows a Consensus Seeking decision making model. When an agenda item has appeared to reach a consensus the moderator will ask "Does anyone object?" as a final call for dissent from the consensus.
 
-If an agenda item cannot reach a consensus a CC member can call for either a closing vote or a vote to table the issue to the next meeting. The call for a vote must be seconded by a majority of the CC or else the discussion will continue. Simple majority wins, with the following exceptions, which will require the affirmative vote of two-thirds of the members of the CC to pass:
-
-- Adding or removing members of the CC
-- Changes to the CC Charter (which also require Board approval)
+If an agenda item cannot reach a consensus a CC member can call for either a closing vote or a vote to table the issue to the next meeting. The call for a vote must be seconded by a majority of the CC or else the discussion will continue. Simple majority wins.
 
 Section 9. Roles
 
@@ -85,7 +84,9 @@ Section 10. Definitions
 
 - Contributors: contribute code or other artifacts, but do not have the right to commit to the code base. Contributors work with the Project’s Collaborators to have code committed to the code base. A Contributor may be promoted to a Collaborator by the projects’ Maintainer or the CC. Contributors should rarely be encumbered by the CC and never by the Board.
 - Project: a collaboration effort, e.g. a subsystem, that is organized through the project creation process and approved by the CC.
-Maintainer: a Collaborator within a Core Project elected to represent the Core Project on the CC.
+- Community Project: projects within the Node.js Foundation or in the ecosystem that contribute to the health of the Node.js project.
+- Adviser: a Collaborator within a Community Project elected to represent the Community Project on the CC.
+- Member: a person who participates in the development of the Community Committee through code or other artifacts.
 
 For the current list of CC members, see the project
 [README.md](./README.md#community-committee-collaborators).

--- a/GOVERNANCE.MD
+++ b/GOVERNANCE.MD
@@ -1,6 +1,91 @@
 # Community Committee Governance
 
-The Community Committee governance is currently under pull request as the Community Committee Charter.
+Section 1. Guiding Principle.
+
+The Node.js Foundation will operate transparently, openly, collaboratively, and ethically. Project proposals, timelines, and status must not merely be open, but also easily visible to the entire ecosystem.
+
+Section 2. Evolution of Node.js Foundation Governance.
+
+Most large, complex open source communities have both a business and a technical governance model. Node.js Foundation’s leadership contains both a Technical Steering Committee (“TSC”) and Maintainers for major components or subsystems. Node.js Foundation’s business leadership is instantiated in a Board of Directors (the “Board”). Community activities, such as events, fall outside of the realm of code and documentation that the TSC oversees. The champions of these organizations have very different skillsets, talents, and concerns. The community organizations of Node.js have long been important to the growth and vitality of the project and will be recognized as the Community Committee(CC) as represented on the Board by the existing Individual Membership Board Directors.
+
+This Community Committee Charter reflects a formal role and the relevance of the voice of community for the governance of Node.js Foundation. The charter amendment process is for the Community Committee(CC) to propose changes using simple majority of the full CC, the proposed changes being subject to review and approval by the Board. The Board may additionally make amendments to the CC charter at any time, though the Board will not interfere with day-to-day discussions, votes or meetings of the CC.
+
+Section 3. Board’s Role in Setting Node.js Foundation’s Strategic Direction.
+
+The Board will set the overall CC Policy. The policy will describe the overarching scope of the Node.js Foundation initiative, Node.js Foundation’s community vision, direction and expectations in the form of intent. The Board will use the CC as a delegate body for community representation, advisement, and overseeing cultural project implementation, scope and direction while they remain within the scope and direction of the policies as described in the CC Policy document and approved by the Board.
+
+Section 4. Establishment of the Community Committee.
+
+CC memberships are not time-limited. There is no fixed size of the CC. However, the expected target is between 9 and 12, to ensure adequate coverage of important areas of community expertise, balanced with the ability to make decisions efficiently.
+
+There is no specific set of requirements or qualifications for CC membership beyond these rules. The CC may add additional members to the CC by a standard CC motion and vote. A CC member may be removed from the CC by voluntary resignation, or by a standard CC motion.
+
+Changes to CC membership should be posted in the agenda, and may be suggested as any other agenda item.
+
+No more than one-fourth of the CC members may be affiliated with the same employer or leadership of a community/ecosystem organization. If removal or resignation of a CC member, or a change of employment by a CC member, creates a situation where more than one-fourth of the CC membership shares an employer, then the situation must be immediately remedied by the resignation or removal of one or more CC members affiliated with the over-represented employer(s).
+
+The CC members shall consist of active members of Community Projects as defined in Section 7.
+
+The CC shall meet regularly using tools that enable participation by the community (e.g. weekly on a Google Hangout On Air, or through any other appropriate means selected by the CC). The meeting shall be directed by the CC Chairperson. Minutes or an appropriate recording shall be taken and made available to the community through accessible public postings.
+
+Section 5. Responsibilities of the CC.
+
+Subject to such policies as may be set by the Board, the CC is responsible for all cultural development and outreach within the Node.js Foundation, including:
+
+- Outreach to community organizations
+- Documentation of community organizations
+- Cultural direction of Node.js Foundation
+- Overseeing Inclusivity WG
+- Project governance and process (including this policy)
+- Recommendations for building and developing community projects that align with needs of Node.js
+- Mediating cultural conflicts between Foundation and/or community projects
+- The CC will serve as Node.js Foundation’s primary community liaison body with external open source projects, consortiums and groups.
+
+Section 6. Node.js Foundation Operations.
+
+The CC will establish and maintain a process of support for Node.js community projects. The process will establish guidelines for how culture and values of the community can be supported.
+
+
+
+The CC is responsible for vetting organizations that will be supported through means such as monetary sponsorship, promotion, resource provisioning, etc. for example requirements such as the organization in question having and executing a Code of Conduct or not conflicting with Node.js Foundation’s goals and priorities.
+
+The CC and entire technical community will follow any processes as may be specified by the Board relating to the intake and license compliance review of contributions, including the Node.js Foundation IP Policy.
+
+Section 7. Elections
+
+Leadership roles in Node.js Foundation Community Committee will be peer elected representatives of the community organizations.
+
+For election of persons (CC Chairperson, Advisors, etc.) a multiple-candidate method should be used, e.g.:
+
+- ●  Condorcet: http://en.wikipedia.org/wiki/Condorcet_method or
+- ●  Single Transferable Vote: http://en.wikipedia.org/wiki/Single_transferable_vote
+
+Multiple-candidate methods may be reduced to simple election by plurality when there are only two candidates for one position to be filled. No election is required if there is only one candidate and no objections to the candidate's election. Nominations for organizations that should be represented on the Community Committee will take place in the GitHub repository. A representative for these organizations shall be selected within the organizations by those active in it.
+
+The CC will elect from amongst voting CC members a CC Chairperson to work on building an agenda for CC meetings and collaborate with the Individual Membership Directors the wishes of the CC to the Board for a term of one year according to the Node.js Foundation’s By-laws. The CC shall hold annual elections to select a CC Chairperson; there are no limits on the number of terms a CC Chairperson may serve.
+
+Section 8. Voting
+
+For internal project decisions, Collaborators shall operate under Lazy Consensus. The CC shall establish appropriate guidelines for implementing Lazy Consensus (e.g. expected notification and review time periods) within the development process.
+
+The CC follows a Consensus Seeking decision making model. When an agenda item has appeared to reach a consensus the moderator will ask "Does anyone object?" as a final call for dissent from the consensus.
+
+If an agenda item cannot reach a consensus a CC member can call for either a closing vote or a vote to table the issue to the next meeting. The call for a vote must be seconded by a majority of the CC or else the discussion will continue. Simple majority wins, with the following exceptions, which will require the affirmative vote of two-thirds of the members of the CC to pass:
+
+- Adding or removing members of the CC
+- Changes to the CC Charter (which also require Board approval)
+
+Section 9. Roles
+
+- The Node.js Foundation community git repository will be maintained by the CC and additional Collaborators who are added by the CC on an ongoing basis.
+- Individuals making significant and valuable contributions, “Contributor(s)”, are made Collaborators and given commit-access to the project. These individuals are identified by the CC and their addition as Collaborators is discussed during the weekly CC meeting. Modifications of the contents of the git repository are made on a collaborative basis as defined in the development process.
+- Collaborators may opt to elevate significant or controversial modifications, or modifications that have not found consensus to the CC for discussion by assigning the cc-agenda tag to a pull request or issue. The CC should serve as the final arbiter where required. The CC will maintain and publish a list of current Collaborators by Project, as well as a development process guide for Collaborators and Contributors looking to participate in the effort.
+
+Section 10. Definitions
+
+- Contributors: contribute code or other artifacts, but do not have the right to commit to the code base. Contributors work with the Project’s Collaborators to have code committed to the code base. A Contributor may be promoted to a Collaborator by the projects’ Maintainer or the CC. Contributors should rarely be encumbered by the CC and never by the Board.
+- Project: a collaboration effort, e.g. a subsystem, that is organized through the project creation process and approved by the CC.
+Maintainer: a Collaborator within a Core Project elected to represent the Core Project on the CC.
 
 For the current list of CC members, see the project
 [README.md](./README.md#community-committee-collaborators).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Community Committee
 
-tl;dr The Community Committee will tackle tasks for Foundation efforts that fall outside of Node.js Core. This group accountable to the Board is directly accountable to the Board. All new initiatives require Board approval
+tl;dr The Community Committee will tackle tasks for Foundation efforts that fall outside of Node.js Core. This group is directly accountable to the Board. All new initiatives require Board approval
 
 The Community Committee reflects a formal role and the relevance of the voice of community for the governance of Node.js Foundation.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Community Committee
+
+tl;dr The Community Committee will tackle tasks for Foundation efforts that fall outside of Node.js Core. This group accountable to the Board is directly accountable to the Board. All new initiatives require Board approval
+
 The Community Committee reflects a formal role and the relevance of the voice of community for the governance of Node.js Foundation.
 
 Community activities, such as ecosystem projects and events, fall outside of the realm of code and documentation that the TSC oversees. Node.js' leadership is instantiated in a Board of Directors. There are are number of organizations that have absolutely contributed to the growth of Node.js--NodeSchool, NodeBots, and thousands of individual meetups. This is not an exhaustive list.The champions of these organizations have very different skillsets, talents, and concerns. The community organizations of Node.js have long been important to the growth and vitality of the project and will be recognized as the Community Committee(CC) as represented on the Board by the existing Individual Membership Board Directors.


### PR DESCRIPTION
This charter is very strongly influenced by the TSC charter(should I add atttribution?). Please pour through this, as it will very much define our processes for who will represent community organizations and projects in the Community Committee as members.