### PR TITLE
Pull back language about working with external groups.

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -41,7 +41,7 @@ Subject to such policies as may be set by the Board, the CC is responsible for a
 - Project governance and process (including this policy)
 - Recommendations for building and developing community projects that align with needs of Node.js
 - Mediating cultural conflicts between Foundation and/or community projects
-- Serve as Node.js Foundation’s primary community liaison body with external open source projects, consortiums and groups.
+- Facilitation with external open source projects, select consortiums and other outside groups.
 
 Section 6. Node.js Foundation Operations.
 


### PR DESCRIPTION
The foundation can't entirely delegate this responsibility with the scope initially drafted.

In particular, when the foundation works with outside consortiums there can be formal agreements regarding IP that the board and the foundation's legal counsel would need to sign off on.

I walked back the language regarding "primary" and focused it more on what I assume is the expectation of the community committee's role with outside groups.