### PR TITLE
Move Chairperson to top, add note

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Meetings will be broadcast via Google Hangouts, will be announced ahead of time 
 The Community Committee is an autonomous committee that collaborates alongside the [TSC](https://github.com/nodejs/TSC) and whose governance is strongly influenced by the [TSC](https://github.com/nodejs/TSC)'s example. See [GOVERNANCE.md](./GOVERNANCE.md) to learn more about the group's evolving structure and [CONTRIBUTING.md](./CONTRIBUTING.md) for guidance about the expectations for all contributors to this project.
 
 ### Community Committee Collaborators
+- Bryan Hughes ([nebrius](https://github.com/nebrius) - **Community Committee Chair**)
 - Ashley Williams ([ashleygwilliams](https://github.com/ashleygwilliams))
-- Bryan Hughes ([nebrius](https://github.com/nebrius))
 - Emily Rose ([emilyrose](https://github.com/emilyrose))
 - Gregor Martynus ([gr2m](https://github.com/gr2m))
 - JP Wesselink ([jpwesselink](https://github.com/jpwesselink))


### PR DESCRIPTION
Moves the CC Chairperson (@nebrius) to the top, adds a note that they are the Chairperson. Final step in https://github.com/nodejs/community-committee/issues/30.