### PR TITLE
Create MEMBER_TRAVEL_FUND.MD

### DIFF
--- a/MEMBER_TRAVEL_FUND.MD
+++ b/MEMBER_TRAVEL_FUND.MD
@@ -1,0 +1,41 @@
+## Purpose
+
+To establish and administer a fund for members of the Node.js
+Foundation Community Committee(CommComm) to travel and spread knowledge about and support the foundation
+and the Node.js Foundation projects.
+
+## Restrictions
+
+* Candidates must be CommComm Members of the Node.js project.
+
+## Process
+
+Any member can apply for travel funds. Each request may take up to a month
+for the CommComm to approve or decline.
+
+* Open a pull request against this repository which adds an entry to the table at the bottom of this file.
+ * Include the name of the event you plan to attend.
+ * Include the location of the event and where you will be traveling from.
+ * Include the presentation you intend to give, if applicable.
+ * Include the size of the stipend you wish to receive.
+  * Reimbursement stipends are expected to vary with travel distance.
+* Once the final amount spent is known, update the table again with that information.
+
+The CommComm will consider each proposal in its next regular meeting. While it is
+ultimately at the CommComm's discretion who to approve the following considerations
+are made.
+
+* Impact: Preference given to underserved communities. More specifically,
+within a subject the foundation is trying to promote awareness about (e.g.
+general knowledge about the foundation) there are people, communities and
+geographies where that knowledge is not very widespread. This is where
+preference will be given. For instance, an event in San Francisco would be
+less attractive than an event of the same size in Kansas City.
+* Cost: The larger the stipend the more critically the CommComm will consider the application.
+Budget for this program is a finite resource.
+* Equity: Preference given to individuals who do not have a corporate travel fund and have
+not previously received a stipend.
+
+Name | Event | Kind of participation | Location | Date | Stipend size
+---- | ----- | --------------------- | -------- | ---- | ------------
+Example Person | NINA 2016 | Collaborator Summit and Code & Learn | Austin, TX, US | 29 Nov – 2 Dec 2016 | US$ 2000

--- a/MEMBER_TRAVEL_FUND.MD
+++ b/MEMBER_TRAVEL_FUND.MD
@@ -6,7 +6,7 @@ and the Node.js Foundation projects.
 
 ## Restrictions
 
-* Candidates must be CommComm Members of the Node.js project.
+* Candidates must be a CommComm member, or a member of a team or Working Group overseen by CommComm in the Node.js project.
 
 ## Process
 
@@ -22,8 +22,8 @@ for the CommComm to approve or decline.
 * Once the final amount spent is known, update the table again with that information.
 
 The CommComm will consider each proposal in its next regular meeting. While it is
-ultimately at the CommComm's discretion who to approve the following considerations
-are made.
+ultimately at the CommComm's discretion who to approve, the following considerations
+are made:
 
 * Impact: Preference given to underserved communities. More specifically,
 within a subject the foundation is trying to promote awareness about (e.g.


### PR DESCRIPTION
As discussed in today's CommComm meeting, this creates the process about travel funds for the CommComm, since there is a separate scope of members than the TSC fund. 

A separate issue will be filed about the specific request for the 2017 travel fund allocation.

**ON HOLD**
This PR is on hold for further coordination with the @nodejs/tsc for a joint travel fund.