### PR TITLE
Add cross-coordination guidelines

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -81,18 +81,19 @@ All Board requests should be communicated to the Individual Member Directors fro
 CommComm Chairperson each month as resolutions or updates. Directors present
 at the Board session are responsible for championing these items.
   
-Coordinate with the TSC Director and Chairperson to ensure all relevant CommComm items 
-have been familiarized ahead of the Board meeting. The Chairperson of the CommComm is 
-responsible for communicating to the TSC chair any cross-concerning discussions, 
-attending meetings to coordinate efforts, and see how we need get input from each group.
+The CommComm Chairperson should also coordinate with the TSC Director and Chairperson 
+to ensure all relevant CommComm items have been familiarized ahead of the Board meeting. 
+The Chairperson of the CommComm is responsible for communicating to the TSC chair any 
+cross-concerning discussions, attending meetings to coordinate efforts, and see how we 
+need get input from each group.
   
-Agenda items need to be emailed to the Node.js Executive Director the Thursday prior to 
-each Board meeting. The Board meeting occurs the last Tuesday of every month. In-between 
-meetings, Individual Membership Directors can email important updates to the Board to 
-familiarize topics prior to Board meeting.
+The Individual Member Directors need to email agenda items to the Node.js Executive Director
+the Thursday prior to each Board meeting. The Board meeting occurs the last Tuesday of every
+month. In-between meetings, Individual Membership Directors can email important updates to 
+the Board to familiarize topics prior to Board meeting.
 
 Be mindful about timeframes on needing approval across governing groups and the Board. 
-Some initiatives may take weeks, not days, for the stars to align.
+Some initiatives may take weeks, not days, for everything to align.
 
 <a id="developers-certificate-of-origin"></a>
 ## Developer's Certificate of Origin 1.1
@@ -121,39 +122,4 @@ By making a contribution to this project, I certify that:
   maintained indefinitely and may be redistributed consistent with
   this project or the open source license(s) involved.
 
-## Code of Conduct
-
-This Code of Conduct is adapted from [Rust's wonderful
-CoC](https://github.com/rust-lang/rust/wiki/Note-development-policy#conduct).
-
-* We are committed to providing a friendly, safe and welcoming
-  environment for all, regardless of gender, sexual orientation,
-  disability, ethnicity, religion, or similar personal characteristic.
-* Please avoid using overtly sexual nicknames or other nicknames that
-  might detract from a friendly, safe and welcoming environment for
-  all.
-* Please be kind and courteous. There's no need to be mean or rude.
-* Respect that people have differences of opinion and that every
-  design or implementation choice carries a trade-off and numerous
-  costs. There is seldom a right answer.
-* Please keep unstructured critique to a minimum. If you have solid
-  ideas you want to experiment with, make a fork and see how it works.
-* We will exclude you from interaction if you insult, demean or harass
-  anyone.  That is not welcome behaviour. We interpret the term
-  "harassment" as including the definition in the [Citizen Code of
-  Conduct](http://citizencodeofconduct.org/); if you have any lack of
-  clarity about what might be included in that concept, please read
-  their definition. In particular, we don't tolerate behavior that
-  excludes people in socially marginalized groups.
-* Private harassment is also unacceptable. No matter who you are, if
-  you feel you have been or are being harassed or made uncomfortable
-  by a community member, please contact one of the channel ops or any
-  of the TC members immediately with a capture (log, photo, email) of
-  the harassment if possible.  Whether you're a regular contributor or
-  a newcomer, we care about making this community a safe place for you
-  and we've got your back.
-* Likewise any spamming, trolling, flaming, baiting or other
-  attention-stealing behaviour is not welcome.
-* Avoid the use of personal pronouns in code comments or
-  documentation. There is no need to address persons when explaining
-  code (e.g. "When the developer")
+## [Code of Conduct](https://github.com/nodejs/community-committee/blob/master/CODE_OF_CONDUCT.md)

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -76,6 +76,24 @@ where a pull request:
 
 The CC Members should serve as the final arbiter where required.
 
+### Cross-coordination Guidelines to Other Governing Groups
+All Board requests should be communicated to the Individual Member Directors from the 
+CommComm Chairperson each month as resolutions or updates. Directors present
+at the Board session are responsible for championing these items.
+  
+Coordinate with the TSC Director and Chairperson to ensure all relevant CommComm items 
+have been familiarized ahead of the Board meeting. The Chairperson of the CommComm is 
+responsible for communicating to the TSC chair any cross-concerning discussions, 
+attending meetings to coordinate efforts, and see how we need get input from each group.
+  
+Agenda items need to be emailed to the Node.js Executive Director the Thursday prior to 
+each Board meeting. The Board meeting occurs the last Tuesday of every month. In-between 
+meetings, Individual Membership Directors can email important updates to the Board to 
+familiarize topics prior to Board meeting.
+
+Be mindful about timeframes on needing approval across governing groups and the Board. 
+Some initiatives may take weeks, not days, for the stars to align.
+
 <a id="developers-certificate-of-origin"></a>
 ## Developer's Certificate of Origin 1.1
 


### PR DESCRIPTION
Provide guidelines for individual membership directors and commcomm chair for coordinating work to success