### PR TITLE
Adding the Evangelism WG

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Meetings will be broadcast via Google Hangouts, will be announced ahead of time 
 - [Community Events](https://github.com/nodejs/community-events)
 
 ### Working Groups
-- None
+- [Evangelism](https://github.com/nodejs/evangelism)
 
 ## Governance and Current Members
 


### PR DESCRIPTION
This officially adds the Evanglism WG to the Community Committee, as per the decision in https://github.com/nodejs/community-committee/issues/86.