### PR TITLE
[membership] Remove Rod Vagg from README.md as member

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ The Community Committee is an autonomous committee that collaborates alongside t
 - Olivia Hugger ([pup](https://github.com/pup))
 - Rachel White ([rachelnicole](https://github.com/rachelnicole))
 - Richard Littauer ([RichardLitt](https://github.com/RichardLitt))
-- Rod Vagg ([rvagg](https://github.com/rvagg))
 - Tracy Hinds ([hackygolucky](https://github.com/hackygolucky))
 - William Kapke ([williamkapke](https://github.com/williamkapke))
 - Michelle Garrett ([msmichellegar](https://github.com/msmichellegar))


### PR DESCRIPTION
This PR Removes @rvagg from CommComm repo, per a personal discussion I had with him. He indicated that he wasn't sure as to the source of his membership in the first place, and that it is safe to remove him.

I looked into it, and https://github.com/nodejs/community-committee/commit/76c9282352846a7096b2165b1e7f2b4c111da479 is the initial commit where Rod was added. It was the second commit to README.md, occuring on Jan 11, which added a suite of context - it also included the first group of Members: Tracy, William, Bryan, Rod, and James. Looks like Rod's membership was more of a first step for the CommComm, not because of a specific (discoverable) ask or request on his end.