### PR TITLE
Removed nebrius

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Meetings will be broadcast via Google Hangouts, will be announced ahead of time 
 The Community Committee is an autonomous committee that collaborates alongside the [TSC](https://github.com/nodejs/TSC) and whose governance is strongly influenced by the [TSC](https://github.com/nodejs/TSC)'s example. See [GOVERNANCE.md](./GOVERNANCE.md) to learn more about the group's evolving structure and [CONTRIBUTING.md](./CONTRIBUTING.md) for guidance about the expectations for all contributors to this project.
 
 ### Community Committee Members
-- Bryan Hughes ([nebrius](https://github.com/nebrius) - **Community Committee Chair**)
 - Jenn Turner ([renrutnnej](https://github.com/renrutnnej) - **Community Committee Secretary**)
 - Tierney Cyren ([bnb](https://github.com/bnb) - **Community Committee Secretary**)
 - Ashley Williams ([ashleygwilliams](https://github.com/ashleygwilliams))


### PR DESCRIPTION
I just learned that @hackygolucky is now acting as standing CommComm chair, and as such there is no longer a need for me to remain on as chair through the election. My apologies for the miscommunication.

Can someone on @nodejs/ctc please remove me from the Node.js org?