### PR TITLE
Resigning from CommComm

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ The Community Committee is an autonomous committee that collaborates alongside t
 
 ### Community Committee Members
 - Tracy Hinds ([hackygolucky](https://github.com/hackygolucky) - **Acting Community Committee Chair**)
-- Jenn Turner ([renrutnnej](https://github.com/renrutnnej) - **Community Committee Secretary**)
 - Tierney Cyren ([bnb](https://github.com/bnb) - **Community Committee Secretary**)
 - Ashley Williams ([ashleygwilliams](https://github.com/ashleygwilliams))
 - Emily Rose ([Amorelandra](https://github.com/Amorelandra))


### PR DESCRIPTION
I’m resigning from the Community Committee because I no longer feel I can be a productive member and wish to put my energy elsewhere needed in my life. Best of luck to the remaining team; I wish you endurance and wisdom in tackling the many pervasive issues in the Node.js community.