### PR TITLE
Fix CoC section in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 The Code of Conduct explains the *bare minimum* behavior
 expectations the Node Foundation requires of its contributors.
-[Please read it before participating.](https://github.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md)
+[Please read it before participating.](https://github.com/nodejs/TSC/blob/master/CODE_OF_CONDUCT.md)
 
 ## Vocabulary
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Code of Conduct
 
 The Code of Conduct explains the *bare minimum* behavior
-expectations the Node Foundation requires of its contributors.
+expectations the Node.js Foundation requires of its contributors.
 [Please read it before participating.](https://github.com/nodejs/TSC/blob/master/CODE_OF_CONDUCT.md)
 
 ## Vocabulary

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Code of Conduct
 
 The Code of Conduct explains the *bare minimum* behavior
-expectations the Node.js Foundation requires of its contributors.
+expectations the Node.js Foundation requires from all contributors.
 [Please read it before participating.](https://github.com/nodejs/TSC/blob/master/CODE_OF_CONDUCT.md)
 
 ## Vocabulary


### PR DESCRIPTION
This PR fixes the link to CoC and the name of Node.js Foundation in the CONTRIBUTING.md file.