### PR TITLE
Fixed link to 'Good First Issue' label, now non-existing.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ expectations the Node.js Foundation requires from all contributors.
 
 ## Start Here:
 
-- Take a look at any issues tagged with [Good First Contribution](https://github.com/nodejs/community-committee/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+contribution%22).
+- Take a look at any issues tagged with [Good First Issue](https://github.com/nodejs/community-committee/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).
 
 ## Teams and Working Groups
 The Community Committee represents a collection of teams and working groups that are expressly working toward growing and supporting the overall Node.js community. Node.js as a whole needs a broad range of skills and contributions, which are not necessarily technical in nature, to thrive.


### PR DESCRIPTION
As seen in [this issue, in getting-started](https://github.com/nodejs/getting-started/issues/5#issuecomment-337578703)