### PR TITLE
Add RFC2119 definition

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -92,7 +92,7 @@ If an agenda item cannot reach a consensus a CC member can call for either a clo
 - Adviser: a Collaborator within a Community Project elected to represent the Community Project on the CC.
 - Member: a person who participates in the development of the Community Committee through code or other artifacts.
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in all Community Committee documents are to be interpreted as described in RFC 2119.
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in all Community Committee documents are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
 For the current list of CC members, see the project
 [README.md](./README.md#community-committee-collaborators).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -92,5 +92,7 @@ If an agenda item cannot reach a consensus a CC member can call for either a clo
 - Adviser: a Collaborator within a Community Project elected to represent the Community Project on the CC.
 - Member: a person who participates in the development of the Community Committee through code or other artifacts.
 
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in all Community Committee documents are to be interpreted as described in RFC 2119.
+
 For the current list of CC members, see the project
 [README.md](./README.md#community-committee-collaborators).


### PR DESCRIPTION
Defining "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL"

This is pretty common thing to have.
