### PR TITLE
Refine the path for Observers to become Members

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,11 +66,19 @@ compromise among collaborators be the default resolution mechanism.
 
 # Becoming a Member and Collaborator
 
-To become a member of the Community Committee, start participating! Attend the bi-weekly meetings, investigate issues tagged as `good first issue`,
+To become a Member of the Community Committee, start participating! Attend scheduled meetings, investigate issues tagged as `good first issue`,
 file issues and pull requests, and provide insight via GitHub. Request to become an Observer by
 filing an issue. Once added as an Observer to meetings, we will track attendance and participation
-for 3 months, as according to our [governance guidelines](https://github.com/nodejs/community-committee/blob/master/GOVERNANCE.md#section-4-establishment-of-the-community-committee). If you meet the minimum
-attendance and are participating, the CommComm will vote to add you as a member.
+according to our [governance guidelines](https://github.com/nodejs/community-committee/blob/master/GOVERNANCE.md#section-4-establishment-of-the-community-committee).
+Once you meet the minimum attendance and participation requirements of a Member, you will automatically become a Member.
+To help expedite the process, you are encouraged to open a PR adding yourself, but it is not a requirement. The Chair is
+responsible for keeping the Member list up-to-date, according to the rules outlined here (a PR with approvals is _not_
+required for this).
+
+If any CommComm member has and objection to an Observer eventually becoming a Member, they must raise that objection to
+the Chair, in private, prior to the Observer's eligibility. Resolution steps should be pursued in favor of removing the
+objection so the Observer can become a Member. If resolution is not attainable, the Committee, in private, must vote to
+remove the Observer and restrict them from being an Observer for no less than 6 months.
 
 All participants added as members should be on-boarded in a timely manner, added as a collaborator, and be given write access to the repository.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -24,8 +24,6 @@ Changes to CC membership should be posted in the agenda, and may be suggested as
 
 No more than one-fourth of the CC members may be affiliated with the same employer or leadership of a community/ecosystem organization. If removal or resignation of a CC member, or a change of employment by a CC member, creates a situation where more than one-fourth of the CC membership shares an employer, then the situation must be immediately remedied by the resignation or removal of one or more CC members affiliated with the over-represented employer(s).
 
-The CC members shall consist of active members of Community Projects and the two Individual Membership Directors as defined in Section 10.
-
 The CC may, at its discretion, invite any number of non-voting observers to participate in the public portion of CC discussions and meetings.
 
 The CC shall meet regularly using tools that enable participation by the community (e.g. weekly on a Google Hangout On Air, or through any other appropriate means selected by the CC). The meeting shall be directed by the Individual Membership Directors. Minutes or an appropriate recording shall be taken and made available to the community through accessible public postings.


### PR DESCRIPTION
This change makes membership automatic once the individual has met all requirements. It additionally defines a path for CommComm members to object & resolve to potential new members.

**Here's the breakdown of each change:**
> Once you meet the minimum attendance and participation requirements of a Member, you will automatically become a Member.

This makes it an open & automatic process for everyone. No voting required.

> To help expedite the process, you are encouraged to open a PR adding yourself, but it is not a requirement.

We shouldn't expect ALL CommComm members to be skilled Git users, so only suggest that they open a PR.

> The Chair is responsible for keeping the Member list up-to-date, according to the rules outlined here (a PR with approvals is _not_ required for this).

This defines who is responsible for documenting Member changes and empowering them to do their job unobstructed by other processes that may exist.

> If any CommComm member has and objection to an Observer eventually becoming a Member, they must raise that objection to the Chair, in private, prior to the Observer's eligibility.

This provides a process for Members to raise concerns.

> Resolution steps should be pursued in favor of removing the objection so the Observer can become a Member.

... but always lean towards that inclusive open door.

> If resolution is not attainable, the Committee, in private, must vote to remove the Observer and restrict them from being an Observer for no less than 6 months.

Define how the Committee is to handle a situation that cannot be resolved.


**Additional notes:**
I realize that we have plural "Chairs"... but the document needs to be consistent and the plurality should remain as a temporary exception.

I noticed that our Charter restricts members to individuals from "Community Projects" but that has not been a requirement we've been pursuing- so, I've updated the charter to remove that requirement. I will need to have the Board approve this change. In the off chance that we do not want to remove this restriction, we should notify the current Observers ASAP.