### PR TITLE
Add education repo and alphabetize teams list

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ Community Committee meetings will be broadcast via Google Hangouts, will be anno
 ## Current Teams and Working Groups
 
 ### Teams
-- [Node.js Collection](https://github.com/nodejs/nodejs-collection)
 - [Community Events](https://github.com/nodejs/community-events)
+- [Education](https://github.com/nodejs/education)
+- [Node.js Collection](https://github.com/nodejs/nodejs-collection)
 
 ### Working Groups
 - [Evangelism](https://github.com/nodejs/evangelism)


### PR DESCRIPTION
Per [this discussion](https://github.com/nodejs/community-committee/issues/46) that CommComm approved it moving under their scope. 