### PR TITLE
Request to add dshaw as CommComm member

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The Community Committee is an autonomous committee that collaborates alongside t
 * [amorelandra](https://github.com/Amorelandra) - **Emily Rose** &lt;nexxy@symphonysubconscious.com&gt;
 * [ashleygwilliams](https://github.com/ashleygwilliams) - **Ashley Williams** &lt;ashley666ashley@gmail.com&gt; **Individual Membership Director**
 * [bnb](https://github.com/bnb) - **Tierney Cyren** &lt;hello@bnb.im&gt; - **Community Committee Co-Chair**
+* [dshaw](https://github.com/dshaw) - **Dan Shaw** &lt;dshaw@dshaw.com&gt;
 * [gr2m](https://github.com/gr2m) - **Gregor Martynus** &lt;nodejs.commcomm@martynus.net&gt;
 * [hackygolucky](https://github.com/hackygolucky) - **Tracy Hinds** &lt;tracyhinds@gmail.com&gt;
 * [joesepi](https://github.com/joesepi) - **Joe Sepi** &lt;joesepi@gmail.com&gt;


### PR DESCRIPTION
It has been 3 months since I joined as an observer at the Collab Summit following Node.js Interactive 2017.

I have attended most of the CommComm meetings in that period and have spearheaded the creation of @nodejs/user-feedback under the CommComm charter. Through User Feedback, we have worked with the Node.js Foundation team to create a survey to provide the Benchmarking WG with feedback from the end user community.

It would be my pleasure to become a member of the Community Commitee.