### PR TITLE
Correcting Toby Farley Attendance

### DIFF
--- a/meetings/2017-10-26.md
+++ b/meetings/2017-10-26.md
@@ -24,6 +24,7 @@
 * @Maurice-Hayward (Maurice Hayward - observer)
 * @sarahkconway (Sarah Conway - observer)
 * @dshaw (Dan Shaw - observer)
+* @tobyfarley (Toby Farley - observer)
 
 ## Notes
 

--- a/meetings/2017-11-30.md
+++ b/meetings/2017-11-30.md
@@ -24,6 +24,7 @@ Pooya Paridel (Observer)
 Rafel Ackermann (@refack CommComm)
 Ahmad Bamieh (Observer)
 Benjamin Zaslavsky (@tiriel - Observer)
+Toby Farley (@tobyfarley - Observer)
 
 ## Notes
 


### PR DESCRIPTION
The only meeting I have missed after attending Node Interactive was 11/08/2017. I made changes to the meeting notes to reflect this.