### PR TITLE
Update STRATEGIC-INITIATIVES.md with more up to date champions and links

### DIFF
--- a/STRATEGIC-INITIATIVES.md
+++ b/STRATEGIC-INITIATIVES.md
@@ -20,12 +20,12 @@ and have the support needed.
 | Community Events   | PatrickHeneise                  | https://github.com/nodejs/community-events                       |
 | Education          | Tracy Hinds                     | https://github.com/nodejs/education                              |
 | Evangelism WG      | Tierney Cyren                   | https://github.com/nodejs/evangelism                             |
-| i18n               | Rachel White                    | https://github.com/nodejs/community-committee/issues/114         |
+| i18n               | Ben Michel                      | https://github.com/nodejs/i18n                                   |
 | Node.js Collection | Tierney Cyren                   | https://github.com/nodejs/nodejs-collection                      |
 | NodeTogether       | Rachel White                    | https://github.com/nodejs/community-committee/issues/63          |
 | Office Hours       | Tierney Cyren                   | https://github.com/nodejs/community-committee/issues/157         |
 | User Feedback      | Michael Dawson                  | https://github.com/nodejs/user-feedback                          |
-| Website Redesign   | Olivia Hugger                   | https://github.com/nodejs/nodejs.org/issues/1534                 |
+| Website Redesign   | Olivia Hugger                   | https://github.com/nodejs/website-redesign                       |
 
 # Need Champion for
 


### PR DESCRIPTION
Updates the champion of i18n to @obensource. I _believe_ this has been decided officially in the past, just wanted to make sure we codify it.

Additionally, updating the Links for i18n and Website Redesign to the new, official repositories for each.