### PR TITLE
Update copyright year in MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Node.js Foundation
+Copyright (c) 2018 Node.js Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Purpose
I noticed the copyright date in our MIT license was out of date. This resolves that.