### PR TITLE
Add Adam Miller as a Community Committee member

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Initiatives are projects that the Community Committee and the broader community 
 The Community Committee is an autonomous committee that collaborates alongside the [TSC](https://github.com/nodejs/TSC) and whose governance is strongly influenced by the [TSC](https://github.com/nodejs/TSC)'s example. See [GOVERNANCE.md](./GOVERNANCE.md) to learn more about the group's evolving structure and [CONTRIBUTING.md](./CONTRIBUTING.md) for guidance about the expectations for all contributors to this project.
 
 ### Community Committee Members
-* [amiller-gh](https://github.com/amiller-gh) - **Adam Miller** &lt;email@email.email&gt;
+* [amiller-gh](https://github.com/amiller-gh) - **Adam Miller** &lt;ammiller@linkedin.com&gt;
 * [amorelandra](https://github.com/Amorelandra) - **Emily Rose** &lt;nexxy@symphonysubconscious.com&gt;
 * [ashleygwilliams](https://github.com/ashleygwilliams) - **Ashley Williams** &lt;ashley666ashley@gmail.com&gt; **Individual Membership Director**
 * [bnb](https://github.com/bnb) - **Tierney Cyren** &lt;hello@bnb.im&gt; - **Community Committee Chair**

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Initiatives are projects that the Community Committee and the broader community 
 The Community Committee is an autonomous committee that collaborates alongside the [TSC](https://github.com/nodejs/TSC) and whose governance is strongly influenced by the [TSC](https://github.com/nodejs/TSC)'s example. See [GOVERNANCE.md](./GOVERNANCE.md) to learn more about the group's evolving structure and [CONTRIBUTING.md](./CONTRIBUTING.md) for guidance about the expectations for all contributors to this project.
 
 ### Community Committee Members
+* [amiller-gh](https://github.com/amiller-gh) - **Adam Miller** &lt;email@email.email&gt;
 * [amorelandra](https://github.com/Amorelandra) - **Emily Rose** &lt;nexxy@symphonysubconscious.com&gt;
 * [ashleygwilliams](https://github.com/ashleygwilliams) - **Ashley Williams** &lt;ashley666ashley@gmail.com&gt; **Individual Membership Director**
 * [bnb](https://github.com/bnb) - **Tierney Cyren** &lt;hello@bnb.im&gt; - **Community Committee Chair**


### PR DESCRIPTION
Per @williamkapke's [summary sheet](https://docs.google.com/spreadsheets/d/1PbmX0kYsPekn2ZUI8Nef-UcjxlhwX9r7oHmNdjR4000/edit?usp=sharing) and the last few minutes PRs (just submitted), it seems @amiller-gh has met the observer requirements to join the Community Committee.

This will be pending on a CommComm private vote, following the same process we've followed for other membership additions prior to this point. 

@nodejs/community-committee expect voting links in your inboxes shortly.