### PR TITLE
Draft language based on discussions for CommComm Restructuring Efforts 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ The Community Committee represents a collection of teams and working groups that
 
 You can see the current teams and working groups in the ["Teams and Working Groups"](https://github.com/nodejs/community-committee#current-teams-and-working-groups) section of the README.md file - if there is one that seems to cover an area of particular interest to you, you should take a look at the Team or Working Group's repo to see how you can get further involved.
 
-# Logging Issues
+## Logging Issues
 
 Log an issue for any question or problem you might have. When in doubt, log an issue,
 any additional policies about what to include will be provided in the responses. The only
@@ -35,7 +35,7 @@ add appropriate metadata before the issue is addressed.
 Please be courteous, respectful, and every participant is expected to follow the
 project's Code of Conduct.
 
-# Contributions
+## Contributions
 
 Any change to resources in this repository must be through pull requests. This applies to all changes
 to documentation, code, binary files, etc. Even long term collaborators and WG members must use
@@ -64,20 +64,55 @@ discuss pending contributions in order to find a resolution. It is expected that
 small minority of issues be brought to the WG for resolution and that discussion and
 compromise among collaborators be the default resolution mechanism.
 
-# Becoming a Member and Collaborator
+Collaborators are expected to follow this policy and continue to send pull requests, go through proper review, and have other collaborators merge their pull requests.
 
-To become a member of the Community Committee, start participating! Attend the bi-weekly meetings, investigate issues tagged as `good first issue`,
-file issues and pull requests, and provide insight via GitHub. Request to become an Observer by
-filing an issue. Once added as an Observer to meetings, we will track attendance and participation
-for 3 months, as according to our [governance guidelines](https://github.com/nodejs/community-committee/blob/master/GOVERNANCE.md#section-4-establishment-of-the-community-committee). If you meet the minimum
-attendance and are participating, the CommComm will vote to add you as a member.
+### Becoming a Contributor
 
-All participants added as members should be on-boarded in a timely manner, added as a collaborator, and be given write access to the repository.
+To begin contributing to working groups and initiatives, start participating!
 
-Collaborators are expected to follow this policy and continue to send pull requests, go through
-proper review, and have other collaborators merge their pull requests.
+Attend the meetings of the working group or initiative, investigate issues tagged
+as `good first issue`, open issues and pull requests, or provide insight via GitHub.
 
-# The CommComm Process
+Individuals can open an issue asking to be an Observer of CommComm meetings. You
+can find a great example of such an issue [here](https://github.com/nodejs/community-committee/issues/142)!
+
+### Becoming a Collaborator
+
+CommComm Collaborators are active contributors with write access to the repo(s)
+relevant to their initiative or working group.
+
+Active Contributors of a CommComm initiative or working group can self-select to
+become a Collaborator of that initiative or working group. Active Contributors can
+also be nominated by another Collaborator.
+
+Typical activities of a Collaborator include:
+
+* Helping users and novice contributors
+* Contributing code, non-code, and documentation changes that improve the project
+* Reviewing and commenting on issues and pull requests
+* Participating in working groups or initiatives
+* Merging pull requests
+
+The CommComm periodically reviews the Collaborator list to identify inactive Collaborators.
+Past Collaborators are typically given Emeritus status. Emeriti may request that
+the CommComm restore them to active status.
+
+### Becoming a Member
+
+CommComm Members are administrative and help to remove barriers for initiatives
+and working groups under the CommComm’s scope.
+
+Active Collaborators of a CommComm initiative or working group can self-select to
+become a Member of the CommComm. Active Collaborators can also be nominated by another
+Member.
+
+All collaborators added as CommComm members should be on-boarded in a timely manner
+and be given write access to the repository.
+
+A member's status is contingent on their participation; this is tracked according
+to our [governance guidelines](https://github.com/nodejs/community-committee/blob/master/GOVERNANCE.md#section-4-establishment-of-the-community-committee).
+
+## The CommComm Process
 
 The CommComm uses a "consensus seeking" process for issues that are escalated to the CommComm.
 The group tries to find a resolution that has no open objections among the CommComm members.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ The default for each contribution is that it is accepted once no collaborator ha
 
 In the case of an objection being raised in a pull request by another collaborator, all involved collaborators should seek to arrive at a consensus by way of addressing concerns being expressed by discussion, compromise on the proposed change, or withdrawal of the proposed change.
 
-If a contribution is controversial and collaborators cannot agree about how to get it to land or if it should land then it should be escalated to the WG. WG members should regularly discuss pending contributions in order to find a resolution. It is expected that only a small minority of issues be brought to the WG for resolution and that discussion and compromise among collaborators be the default resolution mechanism.
+If a contribution is controversial and collaborators cannot agree about how to get it to land or if it should land then it should be escalated to the CC. CC members should regularly discuss pending contributions in order to find a resolution. It is expected that only a small minority of issues be brought to the CC for resolution and that discussion and compromise among collaborators be the default resolution mechanism.
 
 Collaborators are expected to follow this policy and continue to send pull requests, go through proper review, and have other collaborators merge their pull requests.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,9 +93,9 @@ can find a great example of such an issue [here](https://github.com/nodejs/commu
 CommComm Collaborators are active contributors with write access to the repo(s)
 relevant to their initiative or working group.
 
-Active Contributors of a CommComm initiative or working group can self-select to
-become a Collaborator of that initiative or working group. Active Contributors can
-also be nominated by another Collaborator.
+Active Contributors of a CommComm initiative or working group can be nominated by
+another Collaborator to become a Collaborator of that initiative or working group.
+On approval by the consensus process, the Contributor becomes a Collaborator.
 
 Typical activities of a Collaborator include:
 
@@ -114,9 +114,9 @@ the CommComm restore them to active status.
 CommComm Members are administrative and help to remove barriers for initiatives
 and working groups under the CommComm’s scope.
 
-Active Collaborators of a CommComm initiative or working group can self-select to
-become a Member of the CommComm. Active Collaborators can also be nominated by another
-Member.
+Active Collaborators of a CommComm initiative or working group can be nominated by
+a CommComm Member to become a Member of CommComm. On approval by the consensus process,
+the Collaborator becomes a Member.
 
 All collaborators added as CommComm members should be on-boarded in a timely manner
 and be given write access to the repository.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,9 +13,21 @@ expectations the Node.js Foundation requires from all contributors.
 * An **Observer** is any individual who has requested or been requested to attend a CommComm meeting.
 * A **Member** is a collaborator with voting rights who has met the requirements of participation to be considered for acceptance, and subsequently voted in by the CommComm voting process.
 
-## Start Here:
+## Choosing a good first Issue to work on
 
-- Take a look at any issues tagged with [Good First Issue](https://github.com/nodejs/community-committee/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).
+Take a look at any issues tagged as `good first issue` to have an easier time getting started on your first contribution!
+
+Below are links to good first issues in several initiatives.
+
+| Initiative         | Good first issues                                                |
+|--------------------|------------------------------------------------------------------|
+| i18n               | https://github.com/nodejs/i18n/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22  |
+| User Feedback      | https://github.com/nodejs/user-feedback/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22 |
+| Website Redesign   | https://github.com/nodejs/badges/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22 |
+| Badges             | https://github.com/nodejs/badges/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22 |
+
+The Community Committee repo also has issues tagged as [good first issue](https://github.com/nodejs/community-committee/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).
+
 
 ## Teams and Working Groups
 The Community Committee represents a collection of teams and working groups that are expressly working toward growing and supporting the overall Node.js community. Node.js as a whole needs a broad range of skills and contributions, which are not necessarily technical in nature, to thrive.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ The default for each contribution is that it is accepted once no collaborator ha
 
 In the case of an objection being raised in a pull request by another collaborator, all involved collaborators should seek to arrive at a consensus by way of addressing concerns being expressed by discussion, compromise on the proposed change, or withdrawal of the proposed change.
 
-If a contribution is controversial and collaborators cannot agree about how to get it to land or if it should land then it should be escalated to the CC. CC members should regularly discuss pending contributions in order to find a resolution. It is expected that only a small minority of issues be brought to the CC for resolution and that discussion and compromise among collaborators be the default resolution mechanism.
+If a contribution is controversial and collaborators cannot agree about how to get it to land or if it should land then it should be escalated to the CommComm. CommComm members should regularly discuss pending contributions in order to find a resolution. It is expected that only a small minority of issues be brought to the CommComm for resolution and that discussion and compromise among collaborators be the default resolution mechanism.
 
 Collaborators are expected to follow this policy and continue to send pull requests, go through proper review, and have other collaborators merge their pull requests.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ expectations the Node.js Foundation requires from all contributors.
 
 * A **Contributor** is any individual creating or commenting on an issue or pull request.
 * A **Collaborator** is a contributor who has been given write access to the repository
-* An **Observer** is any individual who has requested or been requested to attend a CommComm meeting. It is also the first step to becoming a Member.
+* An **Observer** is any individual who has requested or been requested to attend a CommComm meeting.
 * A **Member** is a collaborator with voting rights who has met the requirements of participation to be considered for acceptance, and subsequently voted in by the CommComm voting process.
 
 ## Start Here:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,10 +8,14 @@ expectations the Node.js Foundation requires from all contributors.
 
 ## Vocabulary
 
-* A **Guest** is any individual who has requested or been requested to attend a CommComm meeting.
+* A **Guest** is any individual who has requested or been requested to attend a CommComm
+meeting.
 * A **Contributor** is any individual creating or commenting on an issue or pull request.
-* A **Collaborator** is a contributor who has been given write access to the repository
-* A **Member** is a collaborator with voting rights who has met the requirements of participation to be considered for acceptance, and subsequently voted in by the CommComm voting process.
+* A **Collaborator** is a contributor who has been given write access to the the repo(s)
+relevant to Community Committee initiatives or working groups.
+* A **Member** is a collaborator with voting rights who has met the requirements of
+participation to be considered for acceptance, and subsequently voted in by the CommComm
+voting process.
 
 ## Choosing a good first Issue to work on
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,9 +82,9 @@ You can find a great example of such an issue [here](https://github.com/nodejs/c
 CommComm Collaborators are active contributors with write access to the repo(s)
 relevant to their initiative or working group.
 
-Active Contributors of a CommComm initiative or working group can be nominated by
-another Collaborator to become a Collaborator of that initiative or working group.
-On approval by the consensus process, the Contributor becomes a Collaborator.
+Active Contributors in the CommComm repositories can be nominated by another Collaborator
+to become a Collaborator. On approval by existing Collaborators through the consensus
+process, the nominated Contributor becomes a Collaborator.
 
 Typical activities of a Collaborator include:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,32 +49,17 @@ project's Code of Conduct.
 
 ## Contributions
 
-Any change to resources in this repository must be through pull requests. This applies to all changes
-to documentation, code, binary files, etc. Even long term collaborators and WG members must use
-pull requests.
+Any change to resources in this repository must be through pull requests (colloquially referred to as "PRs"). This applies to all changes, both non-code and code: documentation, process-related contributions, binary files, etc. Even long term collaborators and WG members must use pull requests.
 
 No pull request can be merged without being reviewed.
 
-For non-trivial contributions, pull requests should sit for at least 36 hours to ensure that
-contributors in other timezones have time to review. Consideration should also be given to
-weekends and other holiday periods to ensure active collaborators all have reasonable time to
-become involved in the discussion and review process if they wish.
+For non-trivial contributions, pull requests should sit for at least 36 hours to ensure that contributors in other timezones have time to review. Consideration should also be given to weekends and other holiday periods to ensure active collaborators all have reasonable time to become involved in the discussion and review process if they wish.
 
-The default for each contribution is that it is accepted once no collaborator has an objection.
-During review collaborators may also request that a specific contributor who is most versed in a
-particular area gives a "LGTM" before the PR can be merged. There is no additional "sign off"
-process for contributions to land. Once all issues brought by collaborators are addressed it can
-be landed by any collaborator.
+The default for each contribution is that it is accepted once no collaborator has an objection. During review collaborators may also request that a specific contributor who is most versed in a particular area gives a "LGTM" before the PR can be merged. There is no additional "sign off" process for contributions to land. Once all issues brought by collaborators are addressed, it can be landed by any collaborator.
 
-In the case of an objection being raised in a pull request by another collaborator, all involved
-collaborators should seek to arrive at a consensus by way of addressing concerns being expressed
-by discussion, compromise on the proposed change, or withdrawal of the proposed change.
+In the case of an objection being raised in a pull request by another collaborator, all involved collaborators should seek to arrive at a consensus by way of addressing concerns being expressed by discussion, compromise on the proposed change, or withdrawal of the proposed change.
 
-If a contribution is controversial and collaborators cannot agree about how to get it to land
-or if it should land then it should be escalated to the WG. WG members should regularly
-discuss pending contributions in order to find a resolution. It is expected that only a
-small minority of issues be brought to the WG for resolution and that discussion and
-compromise among collaborators be the default resolution mechanism.
+If a contribution is controversial and collaborators cannot agree about how to get it to land or if it should land then it should be escalated to the WG. WG members should regularly discuss pending contributions in order to find a resolution. It is expected that only a small minority of issues be brought to the WG for resolution and that discussion and compromise among collaborators be the default resolution mechanism.
 
 Collaborators are expected to follow this policy and continue to send pull requests, go through proper review, and have other collaborators merge their pull requests.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,9 @@ expectations the Node.js Foundation requires from all contributors.
 
 ## Vocabulary
 
+* A **Guest** is any individual who has requested or been requested to attend a CommComm meeting.
 * A **Contributor** is any individual creating or commenting on an issue or pull request.
 * A **Collaborator** is a contributor who has been given write access to the repository
-* An **Observer** is any individual who has requested or been requested to attend a CommComm meeting.
 * A **Member** is a collaborator with voting rights who has met the requirements of participation to be considered for acceptance, and subsequently voted in by the CommComm voting process.
 
 ## Choosing a good first Issue to work on
@@ -70,8 +70,8 @@ To begin contributing to working groups and initiatives, start participating!
 Attend the meetings of the working group or initiative, investigate issues tagged
 as `good first issue`, open issues and pull requests, or provide insight via GitHub.
 
-Individuals can open an issue asking to be an Observer of CommComm meetings. You
-can find a great example of such an issue [here](https://github.com/nodejs/community-committee/issues/142)!
+Individuals can open an issue asking to be an invited Guest to CommComm meetings.
+You can find a great example of such an issue [here](https://github.com/nodejs/community-committee/issues/142)!
 
 ### Becoming a Collaborator
 

--- a/Community-Committee-Charter.md
+++ b/Community-Committee-Charter.md
@@ -119,7 +119,7 @@ so by the Board.
 - Contributors: contribute code or other artifacts, but do not have the right to commit to the code base. Contributors work with the Project’s Collaborators to have code committed to the code base. A Contributor may be promoted to a Collaborator by the projects’ Maintainer or the CommComm. Contributors should rarely be encumbered by the CommComm and never by the Board.
 - Project: a collaboration effort, e.g. a subsystem, that is organized through the project creation process and approved by the CommComm.
 - Community Project: projects within the Node.js Foundation or in the ecosystem that contribute to the health of the Node.js project.
-- Adviser: a Collaborator within a Community Project elected to represent the Community Project on the CommComm.
+- Advisor: a Collaborator within a Community Project elected to represent the Community Project on the CommComm.
 - Member: a Collaborator with voting rights who has met the requirements of participation to be considered for acceptance, and subsequently voted in by the CommComm voting process.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in all Community Committee documents are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).

--- a/Community-Committee-Charter.md
+++ b/Community-Committee-Charter.md
@@ -120,7 +120,7 @@ so by the Board.
 - Project: a collaboration effort, e.g. a subsystem, that is organized through the project creation process and approved by the CC.
 - Community Project: projects within the Node.js Foundation or in the ecosystem that contribute to the health of the Node.js project.
 - Adviser: a Collaborator within a Community Project elected to represent the Community Project on the CC.
-- Member: a person who participates in the development of the Community Committee through code or other artifacts.
+- Member: a Collaborator with voting rights who has met the requirements of participation to be considered for acceptance, and subsequently voted in by the CommComm voting process.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in all Community Committee documents are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 

--- a/Community-Committee-Charter.md
+++ b/Community-Committee-Charter.md
@@ -6,41 +6,41 @@ The Community Committee will operate transparently, openly, collaboratively, and
 
 ## Section 2. Evolution of Node.js Foundation Governance.
 
-Most large, complex open source communities have both a business and a technical governance model. Node.js Foundation’s leadership contains both a Technical Steering Committee (“TSC”) and Maintainers for major components or subsystems. Node.js Foundation’s business leadership is instantiated in a Board of Directors (the “Board”). Community activities, such as events, fall outside of the realm of code and documentation that the TSC oversees. The champions of these organizations have very different skillsets, talents, and concerns. The community organizations of Node.js have long been important to the growth and vitality of the project and will be recognized as the Community Committee("CC") as represented on the Board by the existing Individual Membership Board Directors.
+Most large, complex open source communities have both a business and a technical governance model. Node.js Foundation’s leadership contains both a Technical Steering Committee (“TSC”) and Maintainers for major components or subsystems. Node.js Foundation’s business leadership is instantiated in a Board of Directors (the “Board”). Community activities, such as events, fall outside of the realm of code and documentation that the TSC oversees. The champions of these organizations have very different skillsets, talents, and concerns. The community organizations of Node.js have long been important to the growth and vitality of the project and will be recognized as the Community Committee ("CommComm") as represented on the Board by the existing Individual Membership Board Directors.
 
-This Community Committee Charter reflects a formal role and the relevance of the voice of community for the governance of Node.js Foundation. The charter amendment process is for the Community Committee(CC) to propose changes using simple majority of the full CC, the proposed changes being subject to review and approval by the Board. The Board may additionally make amendments to the CC charter at any time, though the Board will not interfere with day-to-day discussions, votes or meetings of the CC.
+This Community Committee Charter reflects a formal role and the relevance of the voice of community for the governance of Node.js Foundation. The charter amendment process is for the CommComm to propose changes using simple majority of the full CommComm, the proposed changes being subject to review and approval by the Board. The Board may additionally make amendments to the CommComm charter at any time, though the Board will not interfere with day-to-day discussions, votes or meetings of the CommComm.
 
 ## Section 3. Board’s Role in Setting Node.js Foundation’s Strategic Direction.
 
-The Board will set the overall CC Policy. The policy will describe the overarching scope of the Node.js Foundation initiative, Node.js Foundation’s community vision, direction and expectations in the form of intent. The Board will use the CC as a delegate body for community representation, advisement, and overseeing cultural project implementation, scope and direction while they remain within the scope and direction of the policies as described in the CC Policy document and approved by the Board.
+The Board will set the overall CommComm Policy. The policy will describe the overarching scope of the Node.js Foundation initiative, Node.js Foundation’s community vision, direction and expectations in the form of intent. The Board will use the CommComm as a delegate body for community representation, advisement, and overseeing cultural project implementation, scope and direction while they remain within the scope and direction of the policies as described in the CommComm Policy document and approved by the Board.
 
 ## Section 4. Establishment of the Community Committee.
 
-Membership is for 6 months. The group will ask on a regular basis if the expiring members would like to stay on. A member just needs to reply to renew. There is no fixed size of the CC. However, the expected target for Advisors, as defined in Section 10, is between 9 and 12, to ensure adequate coverage of important areas of community expertise, balanced with the ability to make decisions efficiently.
+Membership is for 6 months. The group will ask on a regular basis if the expiring members would like to stay on. A member just needs to reply to renew. There is no fixed size of the CommComm. However, the expected target for Advisors, as defined in Section 10, is between 9 and 12, to ensure adequate coverage of important areas of community expertise, balanced with the ability to make decisions efficiently.
 
-There is no specific set of requirements or qualifications for CC membership beyond these rules. The CC may add additional members to the CC by a standard CC motion and vote. A CC member may be removed from the CC by voluntary resignation, or by a standard CC motion.
+There is no specific set of requirements or qualifications for CommComm membership beyond these rules. The CommComm may add additional members to the CommComm by a standard CommComm motion and vote. A CommComm member may be removed from the CommComm by voluntary resignation, or by a standard CommComm motion.
 
-Changes to CC membership should be posted in the agenda, and may be suggested as any other agenda item.
+Changes to CommComm membership should be posted in the agenda, and may be suggested as any other agenda item.
 
-No more than one-fourth of the CC members may be affiliated with the same employer or leadership of a community/ecosystem organization. If removal or resignation of a CC member, or a change of employment by a CC member, creates a situation where more than one-fourth of the CC membership shares an employer, then the situation must be immediately remedied by the resignation or removal of one or more CC members affiliated with the over-represented employer(s).
+No more than one-fourth of the CommComm members may be affiliated with the same employer or leadership of a community/ecosystem organization. If removal or resignation of a CommComm member, or a change of employment by a CommComm member, creates a situation where more than one-fourth of the CommComm membership shares an employer, then the situation must be immediately remedied by the resignation or removal of one or more CommComm members affiliated with the over-represented employer(s).
 
-The CC members shall consist of active members of Community Projects and the two Individual Membership Directors as defined in Section 10.
+The CommComm members shall consist of active members of Community Projects and the two Individual Membership Directors as defined in Section 10.
 
-The CC may, at its discretion, invite any number of non-voting Guests to participate in the public portion of CC discussions and meetings.
+The CommComm may, at its discretion, invite any number of non-voting Guests to participate in the public portion of CommComm discussions and meetings.
 
-The CC shall meet regularly using tools that enable participation by the community (e.g. weekly on a Google Hangout On Air, or through any other appropriate means selected by the CC). The meeting shall be directed by the Individual Membership Directors. Minutes or an appropriate recording shall be taken and made available to the community through accessible public postings.
+The CommComm shall meet regularly using tools that enable participation by the community (e.g. weekly on a Google Hangout On Air, or through any other appropriate means selected by the CommComm). The meeting shall be directed by the Individual Membership Directors. Minutes or an appropriate recording shall be taken and made available to the community through accessible public postings.
 
-CC members are expected to regularly participate in CC activities.
+CommComm members are expected to regularly participate in CommComm activities.
 
-In the case where an individual CC member -- within any three month period -- attends
-fewer than 25% of the regularly scheduled meetings, does not participate in CC
-discussions, and does not participate in CC votes, the member shall be automatically
-removed from the CC. The member may be invited to continue attending CC meetings
+In the case where an individual CommComm member -- within any three month period -- attends
+fewer than 25% of the regularly scheduled meetings, does not participate in CommComm
+discussions, and does not participate in CommComm votes, the member shall be automatically
+removed from the CommComm. The member may be invited to continue attending CommComm meetings
 as a Guest.
 
-## Section 5. Responsibilities of the CC.
+## Section 5. Responsibilities of the CommComm.
 
-Subject to such policies as may be set by the Board, the CC is responsible for all cultural development and outreach within the Node.js Foundation, including:
+Subject to such policies as may be set by the Board, the CommComm is responsible for all cultural development and outreach within the Node.js Foundation, including:
 
 - Outreach to community organizations
 - Documentation of community organizations
@@ -54,50 +54,50 @@ Subject to such policies as may be set by the Board, the CC is responsible for a
 
 ## Section 6. Node.js Foundation Operations.
 
-The CC will establish and maintain a process of support for Node.js community projects. The process will establish guidelines for how culture and values of the community can be supported.
+The CommComm will establish and maintain a process of support for Node.js community projects. The process will establish guidelines for how culture and values of the community can be supported.
 
-The CC is responsible for vetting organizations that will be supported through means such as monetary sponsorship, promotion, resource provisioning, etc. for example requirements such as the organization in question having and executing a Code of Conduct or not conflicting with Node.js Foundation’s goals and priorities.
+The CommComm is responsible for vetting organizations that will be supported through means such as monetary sponsorship, promotion, resource provisioning, etc. for example requirements such as the organization in question having and executing a Code of Conduct or not conflicting with Node.js Foundation’s goals and priorities.
 
-The CC and entire technical community will follow any processes as may be specified by the Board relating to the intake and license compliance review of contributions, including the Node.js Foundation IP Policy.
+The CommComm and entire technical community will follow any processes as may be specified by the Board relating to the intake and license compliance review of contributions, including the Node.js Foundation IP Policy.
 
 ## Section 7. Elections
 
 Leadership roles in Node.js Foundation Community Committee will be peer elected representatives of the community organizations.
 
-For election of persons (CC Chairperson, Advisors, etc.) a multiple-candidate method should be used, e.g.:
+For election of persons (CommComm Chairperson, Advisors, etc.) a multiple-candidate method should be used, e.g.:
 
 - Condorcet: http://en.wikipedia.org/wiki/Condorcet_method or
 - Single Transferable Vote: http://en.wikipedia.org/wiki/Single_transferable_vote
 
 Multiple-candidate methods may be reduced to simple election by plurality when there are only two candidates for one position to be filled. No election is required if there is only one candidate and no objections to the candidate's election. Nominations for organizations that should be represented on the Community Committee will take place in the GitHub repository. A representative for these organizations shall be selected within the organizations by those active in it.
 
-The CC will elect from amongst voting CC members a CC Chairperson to work on building an agenda for CC meetings and collaborate with the Individual Membership Directors the wishes of the CC to the Board for a term of one year according to the Node.js Foundation’s By-laws. The CC shall hold annual elections to select a CC Chairperson; there are no limits on the number of terms a CC Chairperson may serve.
+The CommComm will elect from amongst voting CommComm members a CommComm Chairperson to work on building an agenda for CommComm meetings and collaborate with the Individual Membership Directors the wishes of the CommComm to the Board for a term of one year according to the Node.js Foundation’s By-laws. The CommComm shall hold annual elections to select a CommComm Chairperson; there are no limits on the number of terms a CommComm Chairperson may serve.
 
 ## Section 8. Voting
 
-For internal project decisions, Collaborators shall operate under Lazy Consensus. The CC shall establish appropriate guidelines for implementing Lazy Consensus (e.g. expected notification and review time periods) within the development process.
+For internal project decisions, Collaborators shall operate under Lazy Consensus. The CommComm shall establish appropriate guidelines for implementing Lazy Consensus (e.g. expected notification and review time periods) within the development process.
 
-The CC follows a Consensus Seeking decision making model. When an agenda item has appeared to reach a consensus the moderator will ask "Does anyone object?" as a final call for dissent from the consensus.
+The CommComm follows a Consensus Seeking decision making model. When an agenda item has appeared to reach a consensus the moderator will ask "Does anyone object?" as a final call for dissent from the consensus.
 
-If an agenda item cannot reach a consensus a CC member can call for either a closing vote or a vote to table the issue to the next meeting. The call for a vote must be seconded by a majority of the CC or else the discussion will continue. Simple majority wins.
+If an agenda item cannot reach a consensus a CommComm member can call for either a closing vote or a vote to table the issue to the next meeting. The call for a vote must be seconded by a majority of the CommComm or else the discussion will continue. Simple majority wins.
 
 ## Section 9. Roles
 
 Node.js Foundation git repositories for Community Committee Initiatives
-are maintained by the CC and additional Collaborators who are added by
-the CC on an ongoing basis.
+are maintained by the CommComm and additional Collaborators who are added by
+the CommComm on an ongoing basis.
 
 Individuals making significant and valuable contributions,
 “Contributor(s)”, are made Collaborators and given commit-access to the
-project. These individuals are identified by the CC and their addition
-as Collaborators is discussed during the weekly CC meeting.
+project. These individuals are identified by the CommComm and their addition
+as Collaborators is discussed during the weekly CommComm meeting.
 Modifications of the contents of the git repository are made on a
 collaborative basis as defined in the development process.
 
 Collaborators may opt to elevate significant or controversial
-modifications, or modifications that have not found consensus to the CC
+modifications, or modifications that have not found consensus to the CommComm
 for discussion by assigning the `cc-agenda` tag to a pull request or
-issue. The CC should serve as the final arbiter where required. The CC
+issue. The CommComm should serve as the final arbiter where required. The CommComm
 will maintain and publish a list of current Collaborators by Project, as
 well as a development process guide for Collaborators and Contributors
 looking to participate in the development effort.
@@ -107,22 +107,22 @@ project’s community voice on the board. There are two individual directors
 that sit on the Node.js Foundation board and they each serve a two-year term.
 Each Individual Membership Director is responsible for soliciting feedback and
 data that represents the wishes of other individual members and the community
-at large. These directors participate and observe CC meetings in order to deliver
+at large. These directors participate and observe CommComm meetings in order to deliver
 monthly updates to the Board of the project. They deliver monthly updates to the
-CC on what the Board is doing. They have been entrusted with the duty to make
+CommComm on what the Board is doing. They have been entrusted with the duty to make
 decisions based on the information they receive to best represent the community,
 and can gather input for proposals when relevant and granted permission to do
 so by the Board.
 
 ## Section 10. Definitions
 
-- Contributors: contribute code or other artifacts, but do not have the right to commit to the code base. Contributors work with the Project’s Collaborators to have code committed to the code base. A Contributor may be promoted to a Collaborator by the projects’ Maintainer or the CC. Contributors should rarely be encumbered by the CC and never by the Board.
-- Project: a collaboration effort, e.g. a subsystem, that is organized through the project creation process and approved by the CC.
+- Contributors: contribute code or other artifacts, but do not have the right to commit to the code base. Contributors work with the Project’s Collaborators to have code committed to the code base. A Contributor may be promoted to a Collaborator by the projects’ Maintainer or the CommComm. Contributors should rarely be encumbered by the CommComm and never by the Board.
+- Project: a collaboration effort, e.g. a subsystem, that is organized through the project creation process and approved by the CommComm.
 - Community Project: projects within the Node.js Foundation or in the ecosystem that contribute to the health of the Node.js project.
-- Adviser: a Collaborator within a Community Project elected to represent the Community Project on the CC.
+- Adviser: a Collaborator within a Community Project elected to represent the Community Project on the CommComm.
 - Member: a Collaborator with voting rights who has met the requirements of participation to be considered for acceptance, and subsequently voted in by the CommComm voting process.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in all Community Committee documents are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
-For the current list of CC members, see the project
+For the current list of CommComm members, see the project
 [README.md](./README.md#community-committee-collaborators).

--- a/Community-Committee-Charter.md
+++ b/Community-Committee-Charter.md
@@ -125,4 +125,4 @@ so by the Board.
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in all Community Committee documents are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
 For the current list of CommComm members, see the project
-[README.md](./README.md#community-committee-collaborators).
+[README.md](./README.md#community-committee-members).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -123,8 +123,8 @@ the CC restore them to active status.
 
 ### Community Committee Member
 
-Active Collaborators of a CC initiative or working group can be nominated by
-a CommComm Member to become a Member of CommComm. On approval by the consensus process,
+Active Collaborators of a CC initiative or working group can self-nominate or be nominated
+by a CommComm Member to become a Member of CommComm. On approval by the consensus process,
 the Collaborator becomes a Member.
 
 Collaborators voted in as Members are given write access to all repositories of

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -79,9 +79,24 @@ If an agenda item cannot reach a consensus a CC member can call for either a clo
 
 ## Section 9. Roles
 
-- The Node.js Foundation community git repository will be maintained by the CC and additional Collaborators who are added by the CC on an ongoing basis.
+The Node.js Foundation community git repository will be maintained by the CC and additional Collaborators who are added by the CC on an ongoing basis.
+
+### Contributor(s)
+
+People start out as contributors. A “Contributor” is any individual participating in working groups or initiatives of the Community Committee by:
+
+* commenting on an issue or pull request, OR
+* creating an issue or pull request
+
+Contributors have no special access to the repositories under the Community Committee.
+
+### Community Committee Collaborator(s) (or more acceptable term, pending TSC input)
+
 - Individuals making significant and valuable contributions, “Contributor(s)”, are made Collaborators and given commit-access to the project. These individuals are identified by the CC and their addition as Collaborators is discussed during the weekly CC meeting. Modifications of the contents of the git repository are made on a collaborative basis as defined in the development process.
 - Collaborators may opt to elevate significant or controversial modifications, or modifications that have not found consensus to the CC for discussion by assigning the cc-agenda tag to a pull request or issue. The CC should serve as the final arbiter where required. The CC will maintain and publish a list of current Collaborators by Project, as well as a development process guide for Collaborators and Contributors looking to participate in the effort.
+
+### Community Committee Member
+
 - Individual Membership Directors of the Node.js Foundation are the Node.js project’s community voice on the board. There are two individual directors that sit on the Node.js Foundation board and they each serve a two-year term. Each Individual Membership Director is responsible for soliciting feedback and data that represents the wishes of other individual members and the community at large. These directors participate and observe CC meetings in order to deliver monthly updates to the Board of the project. They deliver monthly updates to the CC on what the Board is doing. They have been entrusted with the duty to make decisions based on the information they receive to best represent the community, and can gather input for proposals when relevant and granted permission to do so by the Board.
 
 ## Section 10. Definitions

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,7 +1,7 @@
-# Node.js Community Committee (CC) Governance
+# Node.js Community Committee (CommComm) Governance
 
 The Node.js Community Committee initiatives are governed by its Collaborators,
-including the Community Commitee (CC) which is responsible for high-level guidance of the
+including the Community Commitee (CommComm) which is responsible for high-level guidance of the
 initiatives.
 
 <!-- TOC -->
@@ -11,7 +11,7 @@ initiatives.
 - [Collaborators](#collaborators)
   - [Collaborator Activities](#collaborator-activities)
 - [Members](#members)
-  - [CC Meetings](#cc-meetings)
+  - [CommComm Meetings](#CommComm-meetings)
 - [Collaborator Nominations](#collaborator-nominations)
   - [Onboarding](#onboarding)
 - [Consensus Seeking Process](#consensus-seeking-process)
@@ -63,7 +63,7 @@ the CommComm restore them to active status.
 
 ## Members
 
-Active Collaborators of a CC initiative or working group
+Active Collaborators of a CommComm initiative or working group
 can self-nominate or be nominated by a CommComm Member to
 become a Member of CommComm. On approval by the consensus
 process, the Collaborator becomes a Member.
@@ -71,25 +71,25 @@ process, the Collaborator becomes a Member.
 Collaborators voted in as Members are given write access to all repositories of
 the Community Committee, the admin repos, and the moderation repo.
 
-CC Members are administrative and help to remove barriers for initiatives and working
-groups under CC’s scope. CC Members are involved primarily with decisions that have
+CommComm Members are administrative and help to remove barriers for initiatives and working
+groups under CommComm’s scope. CommComm Members are involved primarily with decisions that have
 wider reaching effects than within a single initiative or individual working group.
-CC Members are responsible for making decisions when consensus cannot be reached
+CommComm Members are responsible for making decisions when consensus cannot be reached
 among Collaborators.
 
-Working groups and initiatives should check-in with CC. As the CC Members serve
+Working groups and initiatives should check-in with CommComm. As the CommComm Members serve
 as a point of reference for initiatives and working groups, this check-in helps
 to keep all stakeholders across the Node.js project up-to-date. This improves the
 initiatives' and working groups' accountability and success.
 
-### CC Meetings
+### CommComm Meetings
 
-The CC meets regularly in a voice conference call. The meeting is run by a
+The CommComm meets regularly in a voice conference call. The meeting is run by a
 designated meeting chair approved by the C. Each meeting is streamed on
 YouTube.
 
-Items are added to the CC agenda which are considered contentious or
-are modifications of governance, contribution policy, CC membership,
+Items are added to the CommComm agenda which are considered contentious or
+are modifications of governance, contribution policy, CommComm membership,
 or release process.
 
 The intention of the agenda is not to approve or review all patches.
@@ -97,44 +97,44 @@ That should happen continuously on GitHub and be handled by the larger
 group of Collaborators.
 
 Any community member or contributor can ask that something be reviewed
-by the CC by logging a GitHub issue. Any Collaborator, CC member, or the
-meeting chair can bring the issue to the CC's attention by applying the
-`cc-review` label. If consensus-seeking among CC members fails for a
-particular issue, it may be added to the CC meeting agenda by adding the
+by the CommComm by logging a GitHub issue. Any Collaborator, CommComm member, or the
+meeting chair can bring the issue to the CommComm's attention by applying the
+`cc-review` label. If consensus-seeking among CommComm members fails for a
+particular issue, it may be added to the CommComm meeting agenda by adding the
 `cc-agenda` label.
 
-Prior to each CC meeting, the meeting chair will share the agenda with
-members of the CC. CC members can also add items to the agenda at the
-beginning of each meeting. The meeting chair and the CC cannot veto or remove
+Prior to each CommComm meeting, the meeting chair will share the agenda with
+members of the CommComm. CommComm members can also add items to the agenda at the
+beginning of each meeting. The meeting chair and the CommComm cannot veto or remove
 items.
 
-The CC may invite additional persons to participate in a non-voting capacity.
+The CommComm may invite additional persons to participate in a non-voting capacity.
 
 The meeting chair is responsible for ensuring that minutes are taken and that a
 pull request with the minutes is submitted after the meeting.
 
 Due to the challenges of scheduling a global meeting with participants in
-several timezones, the CC will seek to resolve as many agenda items as possible
+several timezones, the CommComm will seek to resolve as many agenda items as possible
 outside of meetings using
 [the Community-Committee issue tracker](https://github.com/nodejs/community-committee/issues). The process in
 the issue tracker is:
 
-* A CC member opens an issue explaining the proposal/issue and @-mentions
+* A CommComm member opens an issue explaining the proposal/issue and @-mentions
   @nodejs/community-committee.
-* After 72 hours, if there are two or more `LGTM`s from other CC members and no
-  explicit opposition from other CC members, then the proposal is approved.
-* If there are any CC members objecting, then a conversation ensues until
+* After 72 hours, if there are two or more `LGTM`s from other CommComm members and no
+  explicit opposition from other CommComm members, then the proposal is approved.
+* If there are any CommComm members objecting, then a conversation ensues until
   either the proposal is dropped or the objecting members are persuaded. If
   there is an extended impasse, a motion for a vote may be made.
 
 ## Collaborator Nominations
 
-Active Contributors of a CC initiative or working group can be
+Active Contributors of a CommComm initiative or working group can be
 nominated by another Collaborator to become a Collaborator of
 that initiative or working group. Contributors making
 significant, ongoing, and valuable contributions are also
-identified by the CC and their addition as Collaborators is
-discussed during the weekly CC meeting. On approval by the
+identified by the CommComm and their addition as Collaborators is
+discussed during the weekly CommComm meeting. On approval by the
 consensus process, the Contributor becomes a Collaborator and is
 given commit-access to the repo(s) relevant to their initiative.
 
@@ -143,17 +143,17 @@ the responsibility of the Collaborators are made on a
 collaborative basis as defined in the development process.
 Collaborators may opt to elevate significant or controversial
 modifications, or modifications that have not found consensus,
-to the CC for discussion by assigning the cc-agenda tag to a
-pull request or issue. The CC should serve as the final arbiter
-where required. The CC will maintain and publish a list of
+to the CommComm for discussion by assigning the cc-agenda tag to a
+pull request or issue. The CommComm should serve as the final arbiter
+where required. The CommComm will maintain and publish a list of
 current Collaborators by Project, as well as a development
 process guide for Collaborators and Contributors looking to
 participate in the effort.
 
 Collaborators may request Emeritus status when they find themselves inactive. The
-CC also periodically reviews the Collaborator list to identify inactive Collaborators.
+CommComm also periodically reviews the Collaborator list to identify inactive Collaborators.
 Past Collaborators are typically given Emeritus status. Emeriti may request that
-the CC restore them to active status.
+the CommComm restore them to active status.
 
 ### Onboarding
 
@@ -162,10 +162,10 @@ and be given write access to the repository.
 
 ## Consensus Seeking Process
 
-The CC follows a [Consensus Seeking][] decision making model as described by
-the [CC Charter][].
+The CommComm follows a [Consensus Seeking][] decision making model as described by
+the [CommComm Charter][].
 
 [collaborators-discussions]: https://github.com/orgs/nodejs/teams/collaborators/discussions
 [Consensus Seeking]: https://en.wikipedia.org/wiki/Consensus-seeking_decision-making
-[CC Charter]: https://github.com/nodejs/community-committee/blob/master/Community-Committee-Charter.md
+[CommComm Charter]: https://github.com/nodejs/community-committee/blob/master/Community-Committee-Charter.md
 [nodejs/node]: https://github.com/nodejs/node

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -143,7 +143,7 @@ the responsibility of the Collaborators are made on a
 collaborative basis as defined in the development process.
 Collaborators may opt to elevate significant or controversial
 modifications, or modifications that have not found consensus,
-to the CommComm for discussion by assigning the cc-agenda tag to a
+to the CommComm for discussion by assigning the `cc-agenda` tag to a
 pull request or issue. The CommComm should serve as the final arbiter
 where required. The CommComm will maintain and publish a list of
 current Collaborators by Project, as well as a development

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -81,23 +81,73 @@ If an agenda item cannot reach a consensus a CC member can call for either a clo
 
 The Node.js Foundation community git repository will be maintained by the CC and additional Collaborators who are added by the CC on an ongoing basis.
 
-### Contributor(s)
+### Contributor
 
-People start out as contributors. A “Contributor” is any individual participating in working groups or initiatives of the Community Committee by:
+An individual begins contributing as a "Contributor". A contributor is any individual
+participating in working groups or initiatives of the Community Committee by:
 
 * commenting on an issue or pull request, OR
 * creating an issue or pull request
 
 Contributors have no special access to the repositories under the Community Committee.
 
-### Community Committee Collaborator(s) (or more acceptable term, pending TSC input)
+### Community Committee Collaborator (or more acceptable term, pending TSC input)
 
-- Individuals making significant and valuable contributions, “Contributor(s)”, are made Collaborators and given commit-access to the project. These individuals are identified by the CC and their addition as Collaborators is discussed during the weekly CC meeting. Modifications of the contents of the git repository are made on a collaborative basis as defined in the development process.
-- Collaborators may opt to elevate significant or controversial modifications, or modifications that have not found consensus to the CC for discussion by assigning the cc-agenda tag to a pull request or issue. The CC should serve as the final arbiter where required. The CC will maintain and publish a list of current Collaborators by Project, as well as a development process guide for Collaborators and Contributors looking to participate in the effort.
+Active Contributors of a CC initiative or working group can self-select to become
+a Collaborator of that initiative or working group. Active Contributors can also
+be nominated by another Collaborator.
+
+Contributors making significant, ongoing, and valuable contributions are made
+"Collaborators" and given commit-access to the project. Collaborators are contributors
+to individual repos under the CommComm scope. These individuals are identified by
+the CC and their addition as Collaborators is discussed during the weekly CC meeting.
+
+Modifications to the contents of the git repositor(y/ies) under the responsibility
+of the Collaborators are made on a collaborative basis as defined in the development
+process. Collaborators may opt to elevate significant or controversial modifications,
+or modifications that have not found consensus, to the CC for discussion by assigning
+the cc-agenda tag to a pull request or issue. The CC should serve as the final arbiter
+where required. The CC will maintain and publish a list of current Collaborators
+by Project, as well as a development process guide for Collaborators and Contributors
+looking to participate in the effort.
+
+Collaborators may request Emeritus status when they find themselves inactive. The
+CC also periodically reviews the Collaborator list to identify inactive Collaborators.
+Past Collaborators are typically given Emeritus status. Emeriti may request that
+the CC restore them to active status.
 
 ### Community Committee Member
 
-- Individual Membership Directors of the Node.js Foundation are the Node.js project’s community voice on the board. There are two individual directors that sit on the Node.js Foundation board and they each serve a two-year term. Each Individual Membership Director is responsible for soliciting feedback and data that represents the wishes of other individual members and the community at large. These directors participate and observe CC meetings in order to deliver monthly updates to the Board of the project. They deliver monthly updates to the CC on what the Board is doing. They have been entrusted with the duty to make decisions based on the information they receive to best represent the community, and can gather input for proposals when relevant and granted permission to do so by the Board.
+Active Collaborators of a CC initiative or working group can self-select to become
+a member of the CommComm. Active Collaborators can also be nominated by another
+Member.
+
+Collaborators voted in as Members are given write access to all repositories of
+the Community Committee, the admin repos, and the moderation repo.
+
+CC Members are administrative and help to remove barriers for initiatives and working
+groups under CC’s scope. CC Members are involved primarily with decisions that have
+wider reaching effects than within a single initiative or individual working group.
+CC Members are responsible for making decisions when consensus cannot be reached
+among Collaborators.
+
+Working groups and initiatives should check-in with CC. As the CC Members serve
+as a point of reference for initiatives and working groups, this check-in helps
+to keep all stakeholders across the Node.js project up-to-date. This improves the
+initiatives' and working groups' accountability and success.
+
+### Individual Membership Directors
+
+Individual Membership Directors of the Node.js Foundation are the Node.js project’s
+community voice on the board. There are two individual directors that sit on the
+Node.js Foundation board and they each serve a two-year term. Each Individual Membership
+Director is responsible for soliciting feedback and data that represents the wishes
+of other individual members and the community at large. These directors participate
+and observe CC meetings in order to deliver monthly updates to the Board of the
+project. They deliver monthly updates to the CC on what the Board is doing. They
+have been entrusted with the duty to make decisions based on the information they
+receive to best represent the community, and can gather input for proposals when
+relevant and granted permission to do so by the Board.
 
 ## Section 10. Definitions
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -85,7 +85,7 @@ initiatives' and working groups' accountability and success.
 ### CommComm Meetings
 
 The CommComm meets regularly in a voice conference call. The meeting is run by a
-designated meeting chair approved by the C. Each meeting is streamed on
+designated meeting chair approved by the CommComm. Each meeting is streamed on
 YouTube.
 
 Items are added to the CommComm agenda which are considered contentious or

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,6 +1,6 @@
 # Node.js Community Committee (CC) Governance
 
-The Node.js Community Committee initiatives are governeded by its Collaborators,
+The Node.js Community Committee initiatives are governed by its Collaborators,
 including the Community Commitee (CC) which is responsible for high-level guidance of the
 initiatives.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -26,13 +26,17 @@ No more than one-fourth of the CC members may be affiliated with the same employ
 
 The CC members shall consist of active members of Community Projects and the two Individual Membership Directors as defined in Section 10.
 
-The CC may, at its discretion, invite any number of non-voting observers to participate in the public portion of CC discussions and meetings.
+The CC may, at its discretion, invite any number of non-voting Guests to participate in the public portion of CC discussions and meetings.
 
 The CC shall meet regularly using tools that enable participation by the community (e.g. weekly on a Google Hangout On Air, or through any other appropriate means selected by the CC). The meeting shall be directed by the Individual Membership Directors. Minutes or an appropriate recording shall be taken and made available to the community through accessible public postings.
 
 CC members are expected to regularly participate in CC activities.
 
-In the case where an individual CC member -- within any three month period -- attends fewer than 25% of the regularly scheduled meetings, does not participate in CC discussions, and does not participate in CC votes, the member shall be automatically removed from the CC. The member may be invited to continue attending CC meetings as an observer.
+In the case where an individual CC member -- within any three month period -- attends
+fewer than 25% of the regularly scheduled meetings, does not participate in CC
+discussions, and does not participate in CC votes, the member shall be automatically
+removed from the CC. The member may be invited to continue attending CC meetings
+as a Guest.
 
 ## Section 5. Responsibilities of the CC.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -93,14 +93,15 @@ Contributors have no special access to the repositories under the Community Comm
 
 ### Community Committee Collaborator (or more acceptable term, pending TSC input)
 
-Active Contributors of a CC initiative or working group can self-select to become
-a Collaborator of that initiative or working group. Active Contributors can also
-be nominated by another Collaborator.
+Active Contributors of a CC initiative or working group can be nominated by
+another Collaborator to become a Collaborator of that initiative or working group.
+These individuals are identified by the CC and their addition as Collaborators is
+discussed during the weekly CC meeting. On approval by the consensus process,
+the Contributor becomes a Collaborator.
 
 Contributors making significant, ongoing, and valuable contributions are made
 "Collaborators" and given commit-access to the project. Collaborators are contributors
-to individual repos under the CommComm scope. These individuals are identified by
-the CC and their addition as Collaborators is discussed during the weekly CC meeting.
+to individual repos under the CC scope.
 
 Modifications to the contents of the git repositor(y/ies) under the responsibility
 of the Collaborators are made on a collaborative basis as defined in the development
@@ -118,9 +119,9 @@ the CC restore them to active status.
 
 ### Community Committee Member
 
-Active Collaborators of a CC initiative or working group can self-select to become
-a member of the CommComm. Active Collaborators can also be nominated by another
-Member.
+Active Collaborators of a CC initiative or working group can be nominated by
+a CommComm Member to become a Member of CommComm. On approval by the consensus process,
+the Collaborator becomes a Member.
 
 Collaborators voted in as Members are given write access to all repositories of
 the Community Committee, the admin repos, and the moderation repo.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -122,7 +122,7 @@ the issue tracker is:
 * A CC member opens an issue explaining the proposal/issue and @-mentions
   @nodejs/community-committee.
 * After 72 hours, if there are two or more `LGTM`s from other CC members and no
-  explicit opposition from other TSC members, then the proposal is approved.
+  explicit opposition from other CC members, then the proposal is approved.
 * If there are any CC members objecting, then a conversation ensues until
   either the proposal is dropped or the objecting members are persuaded. If
   there is an extended impasse, a motion for a vote may be made.
@@ -162,10 +162,10 @@ and be given write access to the repository.
 
 ## Consensus Seeking Process
 
-The TSC follows a [Consensus Seeking][] decision making model as described by
-the [TSC Charter][].
+The CC follows a [Consensus Seeking][] decision making model as described by
+the [CC Charter][].
 
 [collaborators-discussions]: https://github.com/orgs/nodejs/teams/collaborators/discussions
 [Consensus Seeking]: https://en.wikipedia.org/wiki/Consensus-seeking_decision-making
-[TSC Charter]: https://github.com/nodejs/TSC/blob/master/TSC-Charter.md
+[CC Charter]: https://github.com/nodejs/community-committee/blob/master/Community-Committee-Charter.md
 [nodejs/node]: https://github.com/nodejs/node

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -99,13 +99,10 @@ Contributors have no special access to the repositories under the Community Comm
 
 Active Contributors of a CC initiative or working group can be nominated by
 another Collaborator to become a Collaborator of that initiative or working group.
-These individuals are identified by the CC and their addition as Collaborators is
-discussed during the weekly CC meeting. On approval by the consensus process,
-the Contributor becomes a Collaborator.
-
-Contributors making significant, ongoing, and valuable contributions are made
-"Collaborators" and given commit-access to the project. Collaborators are contributors
-to individual repos under the CC scope.
+Contributors making significant, ongoing, and valuable contributions are also identified
+by the CC and their addition as Collaborators is discussed during the weekly CC meeting.
+On approval by the consensus process, the Contributor becomes a Collaborator and is given
+commit-access to the repo(s) relevant to their initiative.
 
 Modifications to the contents of the git repositor(y/ies) under the responsibility
 of the Collaborators are made on a collaborative basis as defined in the development

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For that reason, we advocate for the usage of a Code of Conduct. We've also lear
 ## Contributing
 > code commits !== the only means to contributions.
 
-The Community Committee is tasked with further building out the Node.js Community.
+The Community Committee is tasked with growing and sustaining the Node.js Community.
 If you're reading this, you're already a part of that community and we'd love to
 have your help!
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ document. This document details the roles you can take on. It also includes a gu
 to contributing and links to `good first issue`s where we're looking for help.
 
 If you're interested in participating in the Community Committee directly, you should
-create an issue asking to be an Observer in our next Community Committee meeting.
+create an issue asking to be a Guest in our next Community Committee meeting.
 You can find a great example of such an issue [here](https://github.com/nodejs/community-committee/issues/142)!
 
 ## Meetings

--- a/README.md
+++ b/README.md
@@ -15,19 +15,31 @@ For that reason, we advocate for the usage of a Code of Conduct. We've also lear
 ## Contributing
 > code commits !== the only means to contributions.
 
-The Community Committee is tasked with further building out the Node.js Community. If you're reading this, you're already a part of that community.
+The Community Committee is tasked with further building out the Node.js Community.
+If you're reading this, you're already a part of that community and we'd love to
+have your help!
 
-As a part of the Node.js Community, we'd love to have your help! To **get started** with contributing, you can check out the Issues in this repository labeled "Good First Issue" to see where we're looking for help. If you have your own ideas on how we could engage and build the community, feel free to create your own issue!
+Before you get started, here's a broad outline of the Community Committee's governance structure:
 
-As a part of the Node.js Community, we'd love to have your help! Before you get started, here's a broad outline of the Community Committee's governance structure:
-
-- Community Commitee (meta-level concerns, cross-cutting with other teams)
+- Community Committee (meta-level concerns, cross-cutting with other teams)
   - Initiatives (focused on specific tasks, independent from the Community Committee). For example, the Website Redesign Initiative, which is focused on a complete redesign of the https://nodejs.org website
   - Working Groups (like initiatives, but more autonomous and broad in scope)
 
-As seen here, most of the community work that immediately affects the project is done within the numerous __initiatives__. We recommend checking the list of initiatives below and getting involved with one that you find interesting! If nothing suits your fancy and you have concrete ideas, just open an issue here! We can help to point you in the right direction.
+As seen here, most of the community work that immediately affects the project is
+done within the numerous **initiatives**. We recommend checking the list of initiatives
+below and getting involved with one that you find interesting! If nothing suits
+your fancy and you have concrete ideas, open an issue here! We can help to point
+you in the right direction.
 
-If you're interested in participating in the Community Committee directly, you should create an issue asking to be an Observer in our next Community Committee meeting. You can find a great example of such an issue [here](https://github.com/nodejs/community-committee/issues/142)!
+To **get started** with contributing, you should read the [Contributing Guidelines](./CONTRIBUTING.md)
+document. This document details the roles you can take on. It also includes a guide
+to contributing and links to `good first issue`s where we're looking for help.
+
+If you're interested in participating in the Community Committee directly, you should
+create an issue asking to be an Observer in our next Community Committee meeting.
+You can find a great example of such an issue [here](https://github.com/nodejs/community-committee/issues/142)!
+
+## Meetings
 
 Community Committee meetings will be broadcast via Zoom, will be announced ahead of time for access, and coordinated to optimize for contributor timezones.
 
@@ -64,7 +76,7 @@ The Community Committee is an autonomous committee that collaborates alongside t
 * [amorelandra](https://github.com/Amorelandra) - **Emily Rose** &lt;nexxy@symphonysubconscious.com&gt;
 * [ashleygwilliams](https://github.com/ashleygwilliams) - **Ashley Williams** &lt;ashley666ashley@gmail.com&gt; **Individual Membership Director**
 * [bnb](https://github.com/bnb) - **Tierney Cyren** &lt;hello@bnb.im&gt; - **Community Committee Chair**
-* [chowdhurian](https://github.com/chowdhurian) - **Manil** &lt;manil.chowdhury@gmail.com&gt;
+* [chowdhurian](https://github.com/chowdhurian) - **Manil Chowdhury** &lt;manil.chowdhury@gmail.com&gt;
 * [dshaw](https://github.com/dshaw) - **Dan Shaw** &lt;dshaw@dshaw.com&gt;
 * [gr2m](https://github.com/gr2m) - **Gregor Martynus** &lt;nodejs.commcomm@martynus.net&gt;
 * [hackygolucky](https://github.com/hackygolucky) - **Tracy Hinds** &lt;tracyhinds@gmail.com&gt;


### PR DESCRIPTION
As per the todo from the last meeting (#285), this PR adds draft language to the relevant documents. It also:

* Removes outdated info from README.md
* Points new contributors at CONTRIBUTING.md
* Adds links to initiatives' good first issues within CONTRIBUTING.md

These drafts are very much a work in progress and relevant to all our work within the CommComm. All your comments and input are requested.

P.S. The Community Committee is abbreviated to "CC" within GOVERNANCE.md. As we generally use "CommComm" in our day-to-day vernacular, it may be worth updating.