### PR TITLE
Remove "Individual Membership Director" title for Ashley Williams

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Individual Membership Directors represent [individual members](https://nodejs.or
 * [MylesBorins](https://github.com/MylesBorins) - **Myles Borins** &lt;myles.borins@gmail.com&gt;
 * [jpwesselink](https://github.com/jpwesselink) - **JP Wesselink** &lt;jpwesselink@gmail.com&gt;
 * [oe](https://github.com/oe) - **Olivia Hugger** &lt;olivia@fastmail.com&gt;
-* [ashleygwilliams](https://github.com/ashleygwilliams) - **Ashley Williams** &lt;ashley666ashley@gmail.com&gt; **Individual Membership Director**
+* [ashleygwilliams](https://github.com/ashleygwilliams) - **Ashley Williams** &lt;ashley666ashley@gmail.com&gt;
 * [gr2m](https://github.com/gr2m) - **Gregor Martynus** &lt;nodejs.commcomm@martynus.net&gt;
 * [amorelandra](https://github.com/Amorelandra) - **Emily Rose** &lt;nexxy@symphonysubconscious.com&gt;
 * [msmichellegar](https://github.com/msmichellegar) - **Michelle Garrett** &lt;msmichellegar@gmail.com&gt;


### PR DESCRIPTION
Updates Ashley William's title, since https://github.com/nodejs/community-committee/pull/330 has now landed.

Thank you to Ashley for the tireless and often thankless work she's put into Node.js, the Node.js Foundation, and the Node.js Foundation board over the last two and a half years 🙏