### PR TITLE
Update Inactive Strategic Initiatives

### DIFF
--- a/STRATEGIC-INITIATIVES.md
+++ b/STRATEGIC-INITIATIVES.md
@@ -17,14 +17,11 @@ and have the support needed.
 
 | Initiative         | Champion                          | Links                                                    |
 |--------------------|-----------------------------------|----------------------------------------------------------|
-| Community Events   | PatrickHeneise                    | https://github.com/nodejs/community-events               |
 | Education          | Tracy Hinds                       | https://github.com/nodejs/education                      |
-| Evangelism WG      | Tierney Cyren                     | https://github.com/nodejs/evangelism                     |
 | i18n               | Ben Michel                        | https://github.com/nodejs/i18n                           |
 | Mentorship         | Ahmad Bamieh _and_ Dan Shaw       | https://github.com/nodejs/mentorship                     |
 | Node.js Collection | Tierney Cyren                     | https://github.com/nodejs/nodejs-collection              |
 | NodeTogether       | Rachel White                      | https://github.com/nodejs/community-committee/issues/63  |
-| Office Hours       | Tierney Cyren                     | https://github.com/nodejs/community-committee/issues/157 |
 | User Feedback      | Dan Shaw                          | https://github.com/nodejs/user-feedback                  |
 | Website Redesign   | Adam Miller _and_ Manil Chowdhury | https://github.com/nodejs/website-redesign               |
 | Badges             | Adam Miller                       | https://github.com/nodejs/badges                         |
@@ -41,9 +38,11 @@ and have the support needed.
 | This week in Core        | ?                               | https://github.com/nodejs/community-committee/issues/148   |
 
 
-# Completed / Retired
+# Completed / Retired / Inactive
 
 | Initiative        | Champion                        | Links                                                            |
 |-------------------|---------------------------------|------------------------------------------------------------------|
-
+| Community Events  | PatrickHeneise                  | https://github.com/nodejs/community-events                       |
+| Evangelism WG     | Tierney Cyren                   | https://github.com/nodejs/evangelism                             |
+| Office Hours      | Tierney Cyren                   | https://github.com/nodejs/community-committee/issues/157         |
 


### PR DESCRIPTION
This PR attempts to move some of the _currently_ inactive initiatives into a place that reflects that. This is not to say that they're ended or over, but trying to reflect the _current_ state of them given the context of their history of activity.

If there is interest in kicking off or restarting these initiatives, I ask that they have well-defined scope, goals, and commitment as agreed upon by the CommComm but not be a cause for the delay of landing of this PR. If needed or wanted, I'd be totally happy to add some documentation about that in the document in a separate PR. 