### PR TITLE
Add dshaw and ljharb as NodeSlackers liasons

### DIFF
--- a/PARTNER_COMMUNITIES.md
+++ b/PARTNER_COMMUNITIES.md
@@ -2,6 +2,8 @@ Node.js has largely been successful because of the grassroots communities that h
 
 The Node.js Community Committee has begun working on partnering with these grassroots communities, to give Node.js and JavaScript developers a path to connecting with other developers with similar interests. Communities that are interested in partnering can follow the guidelines set out within this document and then submit a Pull Request to the document to be added.
 
+Any questions regarding joining or participating in a partner community should be directed to the Node.js Collaborator liaison.
+
 ## Partner Communities
 * [Node Slackers](http://www.nodeslackers.com/)
   * Node.js Collaborator Liaisons: [@dshaw](https://github.com/dshaw) and [@ljharb](https://github.com/ljharb)

--- a/PARTNER_COMMUNITIES.md
+++ b/PARTNER_COMMUNITIES.md
@@ -2,7 +2,7 @@ Node.js has largely been successful because of the grassroots communities that h
 
 The Node.js Community Committee has begun working on partnering with these grassroots communities, to give Node.js and JavaScript developers a path to connecting with other developers with similar interests. Communities that are interested in partnering can follow the guidelines set out within this document and then submit a Pull Request to the document to be added.
 
-Any questions regarding joining or participating in a partner community should be directed to the Node.js Collaborator liaison.
+Any questions regarding joining or participating in a partner community should be directed to a Node.js Collaborator liaison.
 
 ## Partner Communities
 * [Node Slackers](http://www.nodeslackers.com/)

--- a/PARTNER_COMMUNITIES.md
+++ b/PARTNER_COMMUNITIES.md
@@ -4,6 +4,7 @@ The Node.js Community Committee has begun working on partnering with these grass
 
 ## Partner Communities
 * [Node Slackers](http://www.nodeslackers.com/)
+  * Node.js Collaborator Liasons: [@dshaw](https://github.com/dshaw) and [@ljharb](https://github.com/ljharb)
 
 ## Requirements for Becoming a Partner Community:
 * Have a Code of Conduct.

--- a/PARTNER_COMMUNITIES.md
+++ b/PARTNER_COMMUNITIES.md
@@ -4,9 +4,9 @@ The Node.js Community Committee has begun working on partnering with these grass
 
 ## Partner Communities
 * [Node Slackers](http://www.nodeslackers.com/)
-  * Node.js Collaborator Liasons: [@dshaw](https://github.com/dshaw) and [@ljharb](https://github.com/ljharb)
+  * Node.js Collaborator Liaisons: [@dshaw](https://github.com/dshaw) and [@ljharb](https://github.com/ljharb)
 
 ## Requirements for Becoming a Partner Community:
 * Have a Code of Conduct.
 * Have a Moderation Policy.
-* Have a Node.js Collaborator who is willing to act as a liason and is an administrator.
+* Have a Node.js Collaborator who is willing to act as a liaison and is an administrator.


### PR DESCRIPTION
Fixes #381 

Is it worth adding some copy stating that collaborator liaisons are the point of contact for their given communities? Granted, the term `liaison` might make any clarification redundant, but I personally wouldn't think to reach out to the listed Node collaborators if I had trouble getting an invitation to a community.

The copy could be as simple as 
> Any questions regarding joining or participating in a partner community should be directed to the Node.js Collaborator liaison.