### PR TITLE
Specify requirements for partner communities

### DIFF
--- a/PARTNER_COMMUNITIES.md
+++ b/PARTNER_COMMUNITIES.md
@@ -6,6 +6,10 @@ The Node.js Community Committee has begun working on partnering with these grass
 * [Node Slackers](http://www.nodeslackers.com/)
 
 ## Requirements for Becoming a Partner Community:
-* Have a Code of Conduct.
-* Have a Moderation Policy.
+* Have a published Code of Conduct in similar spirit to the [Node.js project](https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md) and are knowledgable in executing on reports by participants and community members.
+* Have a Moderation Policy and enforce it.
 * Have a Node.js Collaborator who is willing to act as a liason and is an administrator.
+* Acknowledgement that the members of CommComm can remove the Partner Community at any time if a report is made in potential violation of the requirements. This interpretation is up to the consideration and discretion of Node.js CommComm to decide.
+
+## Disclaimer
+Node.js Partner Communities empower awesome groups in our global ecosystem by amplifying their voices, providing guidance, and building a knowledge-base of how to build a community. Partner communities as recognized are not official, legal representatives of the Node.js Foundation or project. 


### PR DESCRIPTION
As we grow the partner communities work, we need to document and manage expectations for the communities around the world looking to be amplified by this work that we've discussed in CommComm meetings over the course of this year. 