### PR TITLE
New Member Nomination: @AhmadAwais

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The Community Committee is an autonomous committee that collaborates alongside t
 
 ### Community Committee Members
 * [amiller-gh] - **Adam Miller** &lt;ammiller@linkedin.com&gt; **Community Committee Chair**
+* [AhmadAwais] – **Ahmad Awais** &lt;me@AhmadAwais.com&gt;
 * [bamieh] - **Ahmad Bamieh** &lt;ahmadbamieh@gmail.com&gt;
 * [bnb] - **Tierney Cyren** &lt;hello@bnb.im&gt;
 * [keywordnew] - **Manil Chowdhury** &lt;manil.chowdhury@gmail.com&gt;
@@ -149,6 +150,7 @@ Individual Membership Directors represent individual members of the foundation. 
 
 [amiller-gh]:       https://github.com/amiller-gh
 [amorelandra]:      https://github.com/Amorelandra
+[AhmadAwais]:       https://github.com/AhmadAwais
 [ashleygwilliams]:  https://github.com/ashleygwilliams
 [bamieh]:           https://github.com/bamieh
 [bnb]:              https://github.com/bnb


### PR DESCRIPTION
Hey all!

@AhmadAwais has been kicking butt over on the @nodejs/website-redesign initiative, is a founding member of the @nodejs/outreach initiative, and I'm very excited that he wants to continue to make an investment in Node.js – I am proud to nominate him as a member of the CommComm!

A little background: Ahmad created [vscode.pro](https://vscode.pro), manages the [Developers Takeaway newsletter](https://wptakeaway.club/), maintains 100+ open source packages, is a long-time member of the Wordpress Core Team Dev, a prolific educational content creator, and fierce developer advocate with great experience growing open source communities.

Quick review of the member addition clause in our [governance doc](https://github.com/nodejs/community-committee/tree/master/governance), since its been a while:
> Active Collaborators of a CommComm initiative or working group can self-nominate or be nominated by a CommComm Member to become a Member of CommComm. On approval by the consensus process, the Collaborator becomes a Member.

This issue will be added to the [upcoming April 4th agenda](https://github.com/nodejs/community-committee/issues/461) and, if we have consensus both in this PR, and in a private session at the end of Thursday's webinar, I will merge this following the meeting 🎉