### PR TITLE
Added Bryan Hughes as an emeritus member

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Individual Membership Directors represent individual members of the foundation. 
 * [refack] - **Refael Ackermann** &lt;refack@gmail.com&gt;
 * [JemBijoux] - **Jem Bezooyen** &lt;jem@hipmedia.ca&gt; **Community Committee Secretary**
 * [Tiriel] - **Benjamin Zaslavsky** &lt;benjamin.zaslavsky@gmail.com&gt;
+* [nebrius] - **Bryan Hughes** &lt;bryan@nebri.us&gt; **Community Committee Chairperson**
 
 <!-- Source for Markdown links included in this document -->
 [CommComm]:                    https://github.com/nodejs/community-committee


### PR DESCRIPTION
This has been on my to-do list for a while. When I stepped down, I added myself as an emeritus to the TSC, but forgot to do it for CommComm.

I added myself to the end of the list. Is this the current custom? If so, does this make sense for me to be here or elsewhere in the list since I stepped down in 2017?