### PR TITLE
Added proper link to nebrius' username

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Individual Membership Directors represent individual members of the foundation. 
 [Tiriel]:           https://github.com/Tiriel
 [waleedashraf]:     https://github.com/waleedashraf
 [williamkapke]:     https://github.com/williamkapke
+[nebrius]:          https://github.com/nebrius
 
 [nodejs/badges]:            https://github.com/nodejs/badges
 [nodejs/i18n]:              https://github.com/nodejs/i18n


### PR DESCRIPTION
My apologies, I did not include the link to my username in https://github.com/nodejs/community-committee/pull/480, and it's breaking the README a bit. This PR fixes the missing link.