### PR TITLE
Move @Bamieh to Emeritus

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,6 @@ The Community Committee is an autonomous committee that collaborates alongside t
 ### Community Committee Members
 * [amiller-gh] - **Adam Miller** &lt;adam@mobilize.app&gt;
 * [AhmadAwais] – **Ahmad Awais** &lt;me@AhmadAwais.com&gt;
-* [bamieh] - **Ahmad Bamieh** &lt;ahmadbamieh@gmail.com&gt;
 * [bnb] - **Tierney Cyren** &lt;hello@bnb.im&gt; **Community Committee Chair**
 * [keywordnew] - **Manil Chowdhury** &lt;manil.chowdhury@gmail.com&gt;
 * [codeekage] - **Agiri Abraham Jr.** &lt;agiriabrahamjunior@nodejs.africa&gt;
@@ -147,6 +146,7 @@ Individual Membership Directors represent individual members of the foundation. 
 * [JemBijoux] - **Jem Bezooyen** &lt;jem@hipmedia.ca&gt; **Community Committee Secretary**
 * [Tiriel] - **Benjamin Zaslavsky** &lt;benjamin.zaslavsky@gmail.com&gt;
 * [nebrius] - **Bryan Hughes** &lt;bryan@nebri.us&gt; **Community Committee Chairperson**
+* [bamieh] - **Ahmad Bamieh** &lt;ahmadbamieh@gmail.com&gt;
 
 <!-- Source for Markdown links included in this document -->
 [CommComm]:                    https://github.com/nodejs/community-committee


### PR DESCRIPTION
It was awesome working with all of you; I've learned a lot and hopefully I did a few good things during my time with the commcomm! Sadly I have been inactive at the commcomm level for a while now and I do not see my time freeing up anytime in the near future; So please accept this PR to move me to Emeriti.

I will continue leading the Mentorship initiative. However as I move to Emeriti in the CommComm I would appreciate having someone from the CommComm to act as a mediator between commcomm and mentorship.

Our biweekly mentorship meetings are one day after CommComm meetings (on Fridays same time); Please feel free to join our next meeting. You can find it on the node.js calendar and we schedule meeting issues in https://github.com/nodejs/mentorship.

I hope moving to Emeriti will not affect my activity in mentorship as I am very passionate about this initiative and I wish to continue contributing to the Node.js community through the program.

CC @bnb 