### PR TITLE
Remove individual membership director role and move williamkapke to emeritus

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,12 +125,7 @@ The Community Committee is an autonomous committee that collaborates alongside t
 * [mhdawson] - **Michael Dawson** &lt;michael_dawson@ca.ibm.com&gt;
 * [obensource] - **Ben Michel** &lt;benpmichel@gmail.com&gt;
 * [waleedashraf] - **Waleed Ashraf** &lt;waleedashrafhere@gmail.com&gt;
-* [williamkapke] - **William Kapke** &lt;will@kap.co&gt;
 
-### Individual Membership Directors
-Individual Membership Directors represent individual members of the foundation. They represent both the Individual Membership and Community Committee on the Node.js Board of Directors.
-
-* [williamkapke] - **William Kapke** &lt;will@kap.co&gt;
 
 ### Community Committee Emeriti
 * [ashleygwilliams] - **Ashley Williams** &lt;ashley666ashley@gmail.com&gt;
@@ -147,6 +142,7 @@ Individual Membership Directors represent individual members of the foundation. 
 * [nebrius] - **Bryan Hughes** &lt;bryan@nebri.us&gt; **Community Committee Chairperson**
 * [hackygolucky] - **Tracy Hinds** &lt;tracyhinds@gmail.com&gt;
 * [bamieh] - **Ahmad Bamieh** &lt;ahmadbamieh@gmail.com&gt;
+* [williamkapke] - **William Kapke** &lt;will@kap.co&gt;
 
 <!-- Source for Markdown links included in this document -->
 [CommComm]:                    https://github.com/nodejs/community-committee


### PR DESCRIPTION
Reflection of the state of the world with regard to Individual Membership Directors no longer existing as a role.

Additionally, per the CommComm charter I as chairperson reached out to @williamkapke after a period of inactivity in the work of the Community Committee, and received no indication that he is  interested in participating.  As such, I am moving him to emeritus.