### PR TITLE
Remove User Feedback from Current Initiatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ and have the support needed.
 | Social Media Delegates  | [bnb]                         |                 | [nodejs/social-media-delegates] |
 | Node.js Collection      | [waleedashraf]                |                 | [nodejs/nodejs-collection]      |
 | Outreach                | [AhmadAwais]                  |                 | [nodejs/outreach]               |
-| User Feedback           | [dshaw]                       |                 | [nodejs/user-feedback]          |
 | Website Redesign        | [amiller-gh] and [keywordnew] |                 | [nodejs/nodejs.dev]             |
 | Enterprise User Feeback | Ahmad Nassri                  | [mhdawson]      | [nodejs/user-feedback]          |
 


### PR DESCRIPTION
Removes User Feedback from "Current Initiatives" list in favor of it being in the "In Need of Champion" list. Last commit in the repo was September.