### PR TITLE
README.md updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you're interested in participating in the Community Committee directly, you'r
 
 ## Meetings
 
-Community Committee meetings are broadcast via Zoom. The join link is published in the meeting's respective ssue. Meeting times are coordinated to optimize for contributor timezones.
+Community Committee meetings are broadcast via Zoom. The join link is published in the meeting's respective issue. Meeting times are coordinated to optimize for contributor timezones.
 
 Current meeting cadence is every other week on Thursdays.  Please check the [Node.js Project calendar](https://nodejs.org/calendar) for next scheduled meeting.  Also, the [issues](https://github.com/nodejs/community-committee/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+%22Node.js+Foundation+Community+Committee+Meeting%22) section of this repo will include a CommComm meeting issue, some time before it begins.
 

--- a/README.md
+++ b/README.md
@@ -2,66 +2,49 @@
 
 The Community Committee is a top-level committee in the Node.js Foundation focused on community-facing efforts.
 
-For more details read the [Community Committee Charter], adopted by the Node.js Foundation Board of Directors on March 10th 2017.
+For more details read the [Community Committee Charter].
 
 ## Why does the Community Committee exist?
 
 The Community Committee reflects a formal role and the relevance of the voice of community in the governance of the Node.js project. The formation of this group as a committee alongside the Technical Steering Committee (TSC) demonstrates that community-focused contributions are valued by the contributors of Node.js, and that roles other than those of code contributor help foster a healthy, sustainable open source community.
 
-The Community Committee works to empower people in every part of the project. By making the Node.js project more diverse and improving the environment for inclusivity, we attract a wider range of views, voices, and opinions, which in turn helps us ship better software.
+The Community Committee works to empower people in every part of the project. By focusing on outward-facing community efforts, we aim to make the Node.js project more diverse and improve the environment for inclusivity, attractting a wider range of views, voices, and opinions, which in turn helps us ship better software.
 
-For that reason, we advocate for the usage of a Code of Conduct. We've also learned that our goals are not easily accomplished with that alone. Community Committee initiatives and the related working groups are formed with the intent of improving the cultural development and outreach within the Node.js Foundation, and are therefore suited to engaging people with non-coding skill sets to contribute as well.
+Community Committee initiatives are formed with the intent of improving the cultural development and outreach within the Node.js project, and are therefore suited to engaging people with non-coding skill sets to contribute as well.
 
 ## Contributing
 > code commits !== the only means to contributions.
 
-The Community Committee is tasked with growing and sustaining the Node.js Community.
-If you're reading this, you're already a part of that community and we'd love to
-have your help!
+The Community Committee is tasked with growing and sustaining the Node.js Community. If you're reading this, you're already a part of that community and we'd love to have your help!
 
 Before you get started, here's a broad outline of the Community Committee's governance structure:
 
-- Community Committee (meta-level concerns, cross-cutting with other teams)
-  - Initiatives (focused on specific tasks, independent from the Community Committee). For example, the Website Redesign Initiative, which is focused on a complete redesign of the https://nodejs.org website
-  - Working Groups (like initiatives, but more autonomous and broad in scope)
+- **Community Committee:** meta-level admin concerns, cross-cutting with other groups like the Node.js TSC, OpenJS Foundation CPC, and Working Groups
+  - **Initiatives:** focused on specific tasks, independent from the Community Committee but sharing what they're doing in Community Committee bi-weekly meetings.
 
-As seen here, most of the community work that immediately affects the project is
-done within the numerous **initiatives**. We recommend checking the list of initiatives
-below and getting involved with one that you find interesting! If nothing suits
-your fancy and you have concrete ideas, open an issue here! We can help to point
-you in the right direction.
+As seen here, most of the community work that immediately affects the project is done within the numerous **initiatives**. We recommend checking the [list of initiatives](#strategic-initiatives) below and getting involved with one that you find interesting! If nothing suits your fancy and you have concrete ideas, open an issue here! We can help to point you in the right direction.
 
-To **get started** with contributing, you should read the [Contributing Guidelines](./CONTRIBUTING.md)
-document. This document details the roles you can take on. It also includes a guide
-to contributing and links to `good first issue`s where we're looking for help.
+To **get started** with contributing, you should read the [Contributing Guidelines](./CONTRIBUTING.md) document. This document details the roles you can take on. It also includes a guide to contributing and links to `good first issue`s where we're looking for help.
 
-If you're interested in participating in the Community Committee directly, you should
-create an issue asking to be a Guest in our next Community Committee meeting.
-You can find a great example of such an issue [here](https://github.com/nodejs/community-committee/issues/142)!
+If you're interested in participating in the Community Committee directly, you're more than welcome to join via the Zoom link posted in our bi-weekly meeting issues.
 
 ## Meetings
 
-Community Committee meetings are broadcast via Zoom. The join link is published just before the meeting begins in the meeting issue. Meeting times are coordinated to optimize for contributor timezones.
+Community Committee meetings are broadcast via Zoom. The join link is published in the meeting's respective ssue. Meeting times are coordinated to optimize for contributor timezones.
 
-Current meeting cadence is every other week on Thursdays.  Please check the [Node.js Foundation calendar](https://nodejs.org/calendar) for next scheduled meeting.  Also, the [issues](https://github.com/nodejs/community-committee/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+%22Node.js+Foundation+Community+Committee+Meeting%22) section of this repo will include a CommComm meeting issue, some time before it begins.
+Current meeting cadence is every other week on Thursdays.  Please check the [Node.js Project calendar](https://nodejs.org/calendar) for next scheduled meeting.  Also, the [issues](https://github.com/nodejs/community-committee/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+%22Node.js+Foundation+Community+Committee+Meeting%22) section of this repo will include a CommComm meeting issue, some time before it begins.
 
-We stream our conference call straight to YouTube so anyone can listen to it live, it should start playing at https://www.youtube.com/c/nodejs+foundation/live when we turn it on. There's usually a short cat-herding time at the start of the meeting and then occasionally we have some quick private business to attend to before we can start recording & streaming. Please be patient, and it should show up.
+We stream our conference call straight to YouTube so anyone can listen to it live, it should start playing at https://www.youtube.com/c/nodejs+foundation/live when we turn it on. There's usually a short cat-herding time at the start of the meeting and then occasionally we have some quick private business to attend to before we can start recording and streaming. Please be patient, and it should show up.
 
 ## Strategic Initiatives
+
 Initiatives are projects that the Community Committee and the broader community members are collaborating on to enable Node.js across the ecosystem.
 
-At any one time the Node.js project has a number of strategic initiatives
-underway. With the less-tangible approach to the work that the Community
-Committee does, having a way to track this work is important.
+At any one time the Node.js Community Committee has a number of strategic initiatives underway. With the less-tangible approach to the work that the Community Committee does, having a way to track this work is important.
 
-For each strategic initiative, the Community Committee's goal is to have a
-single point of reference - a champion - that understands what's happening
-with the initiative to the fullest extent possible, and can report on the
-initiative as needed.
+For each strategic initiative, the Community Committee's goal is to have a single point of reference - a champion - that understands what's happening with the initiative to the fullest extent possible, and can report on the initiative as needed.
 
-A review of the initiatives will be a standing item on the Community Committee
-agenda (even if the update is 'nothing new') as a way to ensure they are active
-and have the support needed.
+A review of the initiatives will be a standing item on the Community Committee agenda (even if the update is 'nothing new') as a way to ensure they are active and have the support needed.
 
 ### Current Initiatives
 
@@ -101,7 +84,7 @@ and have the support needed.
 
 ## Labels for Issues and PRs
 
-In an effort to be more concise and distribute our knowledge, we use labels on issues to give context on their status. Here's a guide to how we use labels:
+In an effort to be more concise and distribute our knowledge, we do our best to use labels on issues to give context on their status. Here's a guide to how we use labels:
 
 - `initiative-` prefix: Belonging to or about an initiative that follows the prefix.
 - `waiting-on-` prefix: This indicates that we're waiting on a group for input/feedback.
@@ -112,7 +95,7 @@ In an effort to be more concise and distribute our knowledge, we use labels on i
 
 ## Governance and Current Members
 
-The Community Committee is an autonomous committee that collaborates alongside the [TSC] and whose governance is strongly influenced by the [TSC]'s example. See [GOVERNANCE.md](./GOVERNANCE.md) to learn more about the group's evolving structure and [CONTRIBUTING.md](./CONTRIBUTING.md) for guidance about the expectations for all contributors to this project.
+The Community Committee is an autonomous committee that collaborates alongside the [TSC] and whose governance was strongly influenced by the [TSC]'s example. See [GOVERNANCE.md](./GOVERNANCE.md) to learn more about the group's evolving structure and [CONTRIBUTING.md](./CONTRIBUTING.md) for guidance about the expectations for all contributors to this project.
 
 ### Community Committee Members
 * [amiller-gh] - **Adam Miller** &lt;adam@mobilize.app&gt;

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Community Committee
 
-The Community Committee is a top-level committee in the Node.js Foundation focused on community-facing efforts.
+The Community Committee is a top-level committee in the Node.js Project focused on community-facing efforts.
 
 For more details read the [Community Committee Charter].
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For more details read the [Community Committee Charter].
 
 The Community Committee reflects a formal role and the relevance of the voice of community in the governance of the Node.js project. The formation of this group as a committee alongside the Technical Steering Committee (TSC) demonstrates that community-focused contributions are valued by the contributors of Node.js, and that roles other than those of code contributor help foster a healthy, sustainable open source community.
 
-The Community Committee works to empower people in every part of the project. By focusing on outward-facing community efforts, we aim to make the Node.js project more diverse and improve the environment for inclusivity, attractting a wider range of views, voices, and opinions, which in turn helps us ship better software.
+The Community Committee works to empower people in every part of the project. By focusing on outward-facing community efforts, we aim to make the Node.js project more diverse and improve the environment for inclusivity, attracting a wider range of views, voices, and opinions, which in turn helps us ship better software.
 
 Community Committee initiatives are formed with the intent of improving the cultural development and outreach within the Node.js project, and are therefore suited to engaging people with non-coding skill sets to contribute as well.
 


### PR DESCRIPTION
This PR addresses multiple things:


- Updates some excessively outdated language to reflect reality of the Node.js project at the time of editing, rather than the hopes and goals of the group that worked on the initial draft of CommComm - many of which, like a Code of Conduct and additional community standards, have now been fully realized
- Removes references to "Node.js Foundation", opting for "Node.js Project" instead
- Normalizes white space (previously whitespace was mixed between hard breaks and no breaks)
- Normalizes some markdown formatting
- Adds a few links to help improve navigation through the document
- Updates some prose for clarity