### PR TITLE
Add Meeting Notes to register the meeting was cancelled

### DIFF
--- a/meetings/2019-11-28.md
+++ b/meetings/2019-11-28.md
@@ -1,0 +1,48 @@
+# Node.js Foundation Community Committee Meeting 2019-11-28
+
+## This Meeting Was Cancelled since it was on a US holyday
+
+## Links
+
+* **Recording**: No records since there was no meeting
+* **GitHub Issue**: <https://github.com/nodejs/community-committee/issues/555>
+* **Minutes Google Doc**: <https://docs.google.com/document/d/15VrSzqSxcPWSxG02XojiYw58bxoZ_6jxRxoX69DszGo>
+
+## Present
+
+* CommComm Members: @nodejs/community-committee
+
+Feel free to follow along on the YouTube live stream, or attend meeting as a guest
+by calling in to Zoom, using the links below. If you will be attending as a guest,
+please comment on this issue to let us know you'll be joining.
+
+### *Members and Observers: In order to facilitate attendance tracking, don't hesitate do add yourselves to the minutes doc*
+
+## Agenda
+
+## Announcements
+
+## CPC and Board Meeting Updates
+
+*Extracted from **cc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
+
+### nodejs/admin
+
+* Collaborator Summit - Montreal 2019 [#416](https://github.com/nodejs/admin/issues/416)
+
+### nodejs/community-committee
+
+* Community Committee and OKRs [#547](https://github.com/nodejs/community-committee/issues/547)
+* Initiative #507 — Preparing questions for annual survey [#538](https://github.com/nodejs/community-committee/issues/538)
+* Required updates to CommComm Charter to reflect OpenJS Foundation [#526](https://github.com/nodejs/community-committee/pull/526)
+* Code & Learn in a Box [#503](https://github.com/nodejs/community-committee/issues/503)
+* Node.js Social Media Community Collaboration [#444](https://github.com/nodejs/community-committee/issues/444)
+* Node.js Collection – Next Steps [#439](https://github.com/nodejs/community-committee/issues/439)
+
+## Q&A, Other
+
+## Upcoming Meetings
+
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
+
+Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2019-12-12.md
+++ b/meetings/2019-12-12.md
@@ -1,0 +1,48 @@
+# Node.js Foundation Community Committee Meeting 2019-12-12
+
+## This Meeting Was Cancelled since as most people was at NodeJSInteractive
+
+## Links
+
+* **Recording**: No records since there was no meeting
+* **GitHub Issue**: <https://github.com/nodejs/community-committee/issues/556>
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1vV1ayuQG5RxXk4YTc67v0uxC5kRpv5iqzte4EVir9Hs>
+
+## Present
+
+* CommComm Members: @nodejs/community-committee
+
+Feel free to follow along on the YouTube live stream, or attend meeting as a guest
+by calling in to Zoom, using the links below. If you will be attending as a guest,
+please comment on this issue to let us know you'll be joining.
+
+### *Members and Observers: In order to facilitate attendance tracking, don't hesitate do add yourselves to the minutes doc*
+
+## Agenda
+
+## Announcements
+
+## CPC and Board Meeting Updates
+
+*Extracted from **cc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
+
+### nodejs/admin
+
+* Collaborator Summit - Montreal 2019 [#416](https://github.com/nodejs/admin/issues/416)
+
+### nodejs/community-committee
+
+* Add SauloNunes to the mentorship team [#553](https://github.com/nodejs/community-committee/issues/553)
+* Community Committee and OKRs [#547](https://github.com/nodejs/community-committee/issues/547)
+* Initiative #507 — Preparing questions for annual survey [#538](https://github.com/nodejs/community-committee/issues/538)
+* Code & Learn in a Box [#503](https://github.com/nodejs/community-committee/issues/503)
+* Node.js Social Media Community Collaboration [#444](https://github.com/nodejs/community-committee/issues/444)
+* Node.js Collection – Next Steps [#439](https://github.com/nodejs/community-committee/issues/439)
+
+## Q&A, Other
+
+## Upcoming Meetings
+
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
+
+Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2019-12-26.md
+++ b/meetings/2019-12-26.md
@@ -1,0 +1,44 @@
+# Node.js Foundation Community Committee Meeting 2019-12-26
+
+## This Meeting Was Cancelled since as most people was on Vacation
+
+## Links
+
+* **Recording**: No records since there was no meeting
+* **GitHub Issue**: <https://github.com/nodejs/community-committee/issues/558>
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1KKcjNMBZYtmu1hIzDoS8WS0VhX_L2SHET6ajRAVeNx8>
+
+## Present
+
+* CommComm Members: @nodejs/community-committee
+
+Feel free to follow along on the YouTube live stream, or attend meeting as a guest
+by calling in to Zoom, using the links below. If you will be attending as a guest,
+please comment on this issue to let us know you'll be joining.
+
+### *Members and Observers: In order to facilitate attendance tracking, don't hesitate do add yourselves to the minutes doc*
+
+## Agenda
+
+## Announcements
+
+## CPC and Board Meeting Updates
+
+*Extracted from **cc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
+
+### nodejs/community-committee
+
+* Add SauloNunes to the mentorship team [#553](https://github.com/nodejs/community-committee/issues/553)
+* Community Committee and OKRs [#547](https://github.com/nodejs/community-committee/issues/547)
+* Initiative #507 — Preparing questions for annual survey [#538](https://github.com/nodejs/community-committee/issues/538)
+* Code & Learn in a Box [#503](https://github.com/nodejs/community-committee/issues/503)
+* Node.js Social Media Community Collaboration [#444](https://github.com/nodejs/community-committee/issues/444)
+* Node.js Collection – Next Steps [#439](https://github.com/nodejs/community-committee/issues/439)
+
+## Q&A, Other
+
+## Upcoming Meetings
+
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
+
+Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.


### PR DESCRIPTION
meeting notes from #555 #556 #558 

As mentioned before by @WaleedAshraf  we are registering those meetings that was cancelled 