### PR TITLE
docs: add link to nodejs/examples in initiatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ A review of the initiatives will be a standing item on the Community Committee a
 | Mentorship              | [Bamieh]                      |                 | [nodejs/mentorship]             | |
 | Social Media Delegates  | [bnb]                         |                 | [nodejs/social-media-delegates] | |
 | Node.js Collection      | [waleedashraf]                |                 | [nodejs/nodejs-collection]      | |
-| Examples                | [bnb]                         |                 |                                 | |
+| Examples                | [bnb]                         |                 | [nodejs/examples]               | |
 | Outreach                | [AhmadAwais]                  |                 | [nodejs/outreach]               | |
 | Website Redesign        | [amiller-gh] and [keywordnew] |                 | [nodejs/nodejs.dev]             | [website-redesign OKR] |
 


### PR DESCRIPTION
Adds a link to nodejs/examples now that the repo is up.