### PR TITLE
chore: update @keywordnew to emeritus

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ The Community Committee is an autonomous committee that collaborates alongside t
 ### Community Committee Members
 * [AhmadAwais] – **Ahmad Awais** &lt;me@AhmadAwais.com&gt;
 * [bnb] - **Tierney Cyren** &lt;hello@bnb.im&gt; **Community Committee Chair**
-* [keywordnew] - **Manil Chowdhury** &lt;manil.chowdhury@gmail.com&gt;
 * [codeekage] - **Agiri Abraham Jr.** &lt;agiriabrahamjunior@nodejs.africa&gt;
 * [joesepi] - **Joe Sepi** &lt;joesepi@gmail.com&gt; **Community Committeee CPC Representative**
 * [mhdawson] - **Michael Dawson** &lt;michael_dawson@ca.ibm.com&gt;
@@ -115,6 +114,7 @@ The Community Committee is an autonomous committee that collaborates alongside t
 * [williamkapke] - **William Kapke** &lt;will@kap.co&gt;
 * [amiller-gh] - **Adam Miller** &lt;adam@mobilize.app&gt;
 * [dshaw] - **Dan Shaw** &lt;dshaw@dshaw.com&gt;
+* [keywordnew] - **Manil Chowdhury** &lt;manil.chowdhury@gmail.com&gt;
 
 <!-- Source for Markdown links included in this document -->
 [CommComm]:                    https://github.com/nodejs/community-committee


### PR DESCRIPTION
Hello friends ❤️ I feel this is now long overdue. I haven't been finding enough bandwidth to dedicate the level of time CommComm, Node.js, and OpenJS deserve. It's time for me to accept this reality.

Thus this PR, per CommComm's README.md: _"Collaborators may request Emeritus status when they find themselves inactive."_

I always welcome crossing paths with y'all in open source :-) This isn't the end. I can be reached via email (I read every email I get, eventually) and I'll be back when I'm ready to ramp up contributions. 

My heartfelt gratitude goes out to everyone serving the Node.js project – past, present, and future. Thank you for the good times, the less good, and even the uncertain. It's been quite a ride! From developing CommComm to the metamorphosis into OpenJS, I'm grateful to have had the chance to contribute and learn with all of you 💖