### PR TITLE
move @waleedashraf to emeritus

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ The Community Committee is an autonomous committee that collaborates alongside t
 * [joesepi] - **Joe Sepi** &lt;joesepi@gmail.com&gt; **Community Committeee CPC Representative**
 * [mhdawson] - **Michael Dawson** &lt;michael_dawson@ca.ibm.com&gt;
 * [obensource] - **Ben Michel** &lt;benpmichel@gmail.com&gt;
-* [waleedashraf] - **Waleed Ashraf** &lt;waleedashrafhere@gmail.com&gt;
 * [rachelnicole] - **Rachel White** &lt;loveless@gmail.com&gt;
 
 
@@ -113,6 +112,7 @@ The Community Committee is an autonomous committee that collaborates alongside t
 * [amiller-gh] - **Adam Miller** &lt;adam@mobilize.app&gt;
 * [dshaw] - **Dan Shaw** &lt;dshaw@dshaw.com&gt;
 * [keywordnew] - **Manil Chowdhury** &lt;manil.chowdhury@gmail.com&gt;
+* [waleedashraf] - **Waleed Ashraf** &lt;waleedashrafhere@gmail.com&gt;
 
 <!-- Source for Markdown links included in this document -->
 [CommComm]:                    https://github.com/nodejs/community-committee


### PR DESCRIPTION
Hi Team,
Due to personal work, I haven't been much active in CommComm lately and skipped most of the recent meetings.
Better to update my status as emeritus. I'll still be in touch. You can reach out to me through email/Twitter anytime.

It has been a great pleasure to work with the team for almost 3 years. Thanks to everyone for their support. ❤️ 
